### PR TITLE
[Feature] Extend expectations to take multiple observables.

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -137,7 +137,7 @@ class DQC(Circuit):
     @partial(vmap, in_axes=(None, None, 0))
     def __call__(self, param_values: Array, x: Array) -> Array:
         param_dict = {name: val for name, val in zip(self.param_names, param_values)}
-        return adjoint_expectation(self.state, self.feature_map + self.ansatz, self.observable, {**param_dict, **{'phi': x}})
+        return adjoint_expectation(self.state, self.feature_map + self.ansatz, self.observable, {**param_dict, **{'phi': x}})[0]
 
 
 circ = DQC(n_qubits=n_qubits, feature_map=[RX('phi', i) for i in range(n_qubits)], ansatz=hea(n_qubits, n_layers))

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -80,7 +80,7 @@ def ad_expectation(
 def expectation(
     state: Array,
     gates: GateSequence,
-    observable: list[Primitive],
+    observables: list[Primitive],
     values: dict[str, float],
     diff_mode: DiffMode = DiffMode.AD,
     forward_mode: ForwardMode = ForwardMode.EXACT,

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -92,9 +92,9 @@ def expectation(
     and compute the expectation given an observable.
     """
     if diff_mode == DiffMode.AD:
-        return ad_expectation(state, gates, observable, values)
+        return ad_expectation(state, gates, observables, values)
     elif diff_mode == DiffMode.ADJOINT:
-        return adjoint_expectation(state, gates, observable, values)
+        return adjoint_expectation(state, gates, observables, values)
     elif diff_mode == DiffMode.GPSR:
         checkify.check(
             forward_mode == ForwardMode.SHOTS, "Finite shots and GPSR must be used together"
@@ -105,4 +105,4 @@ def expectation(
         )
         # Type checking is disabled because mypy doesn't parse checkify.check.
         # type: ignore
-        return finite_shots_fwd(state, gates, observable, values, n_shots=n_shots, key=key)
+        return finite_shots_fwd(state, gates, observables, values, n_shots=n_shots, key=key)

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -51,8 +51,8 @@ def sample(
     )
 
 
-def ad_expectation(
-    state: Array, gates: GateSequence, observable: GateSequence, values: dict[str, float]
+def __ad_expectation_single_observable(
+    state: Array, gates: GateSequence, observable: Primitive, values: dict[str, float]
 ) -> Array:
     """
     Run 'state' through a sequence of 'gates' given parameters 'values'
@@ -63,10 +63,24 @@ def ad_expectation(
     return inner(out_state, projected_state).real
 
 
+def ad_expectation(
+    state: Array, gates: GateSequence, observables: list[Primitive], values: dict[str, float]
+) -> Array:
+    """
+    Run 'state' through a sequence of 'gates' given parameters 'values'
+    and compute the expectation given an observable.
+    """
+    outputs = [
+        __ad_expectation_single_observable(state, gates, observable, values)
+        for observable in observables
+    ]
+    return jnp.stack(outputs)
+
+
 def expectation(
     state: Array,
     gates: GateSequence,
-    observable: GateSequence,
+    observable: list[Primitive],
     values: dict[str, float],
     diff_mode: DiffMode = DiffMode.AD,
     forward_mode: ForwardMode = ForwardMode.EXACT,
@@ -86,12 +100,9 @@ def expectation(
             forward_mode == ForwardMode.SHOTS, "Finite shots and GPSR must be used together"
         )
         checkify.check(
-            isinstance(observable, Primitive),
-            "Finite Shots only supports a single Primitive as an observable",
-        )
-        checkify.check(
             type(n_shots) is int,
             "Number of shots must be an integer for finite shots.",
         )
         # Type checking is disabled because mypy doesn't parse checkify.check.
-        return finite_shots_fwd(state, gates, observable, values, n_shots=n_shots, key=key)  # type: ignore
+        # type: ignore
+        return finite_shots_fwd(state, gates, observable, values, n_shots=n_shots, key=key)

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -5,7 +5,8 @@ import numpy as np
 from jax import Array, grad
 
 from horqrux import random_state
-from horqrux.adjoint import adjoint_expectation, expectation
+from horqrux.adjoint import adjoint_expectation
+from horqrux.api import expectation
 from horqrux.parametric import PHASE, RX, RY, RZ
 from horqrux.primitive import NOT, H, I, S, T, X, Y, Z
 
@@ -26,10 +27,10 @@ def test_gradcheck() -> None:
     state = random_state(MAX_QUBITS)
 
     def adjoint_expfn(values) -> Array:
-        return adjoint_expectation(state, ops, observable, values)
+        return adjoint_expectation(state, ops, observable, values)[0]
 
     def ad_expfn(values) -> Array:
-        return expectation(state, ops, observable, values)
+        return expectation(state, ops, observable, values)[0]
 
     grads_adjoint = grad(adjoint_expfn)(values)
     grad_ad = grad(ad_expfn)(values)

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -7,32 +7,32 @@ from horqrux import expectation, random_state
 from horqrux.parametric import RX
 from horqrux.primitive import Z
 
-N_QUBITS = 4
+N_QUBITS = 2
 SHOTS_ATOL = 0.01
-N_SHOTS = 10000
+N_SHOTS = 100_000
 
 
 def test_shots() -> None:
     ops = [RX("theta", 0)]
-    observable = Z(0)
+    observables = [Z(0), Z(1)]
     state = random_state(N_QUBITS)
     x = jnp.pi * 0.5
 
     def exact(x):
         values = {"theta": x}
-        return expectation(state, ops, observable, values, "ad")
+        return expectation(state, ops, observables, values, "ad")
 
     def shots(x):
         values = {"theta": x}
-        return expectation(state, ops, observable, values, "gpsr", "shots", n_shots=N_SHOTS)
+        return expectation(state, ops, observables, values, "gpsr", "shots", n_shots=N_SHOTS)
 
     exp_exact = exact(x)
-    exp_shots = exact(x)
+    exp_shots = shots(x)
 
-    assert jnp.isclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
+    assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
 
-    d_exact = jax.grad(exact)
-    d_shots = jax.grad(shots)
+    d_exact = jax.grad(lambda x: exact(x).sum())
+    d_shots = jax.grad(lambda x: shots(x).sum())
 
     grad_backprop = d_exact(x)
     grad_shots = d_shots(x)


### PR DESCRIPTION
Closes #26 

This MR is a breaking change. As mentioned in #26, the status quo of of expectations in `horqrux` has been that, setting observables `[Z(0), Z(1)]` in an `expectation` call gives something like `<state|Z(1)Z(0)|state>`.

This MR changes this behaviour and returns `[<state|Z(0)|state>, <state|Z(1)|state>]` instead.

In the case direct expectations taken with respect to wavefunctions, then this is done by iterating through the observables directly.

In the case of finite shots, then particular care needs to be taken to correctly handle correlated observables. Some scrutiny on whether this is done correctly would be much appreciated. The initial implementation in the MR permutes the eigenvector matrices of each observable so that they match up and then samples accordingly from those.