### PR TITLE
[Feature] Allow parameter shifting on all parametric gates

### DIFF
--- a/horqrux/adjoint.py
+++ b/horqrux/adjoint.py
@@ -66,7 +66,7 @@ def adjoint_expectation_single_observable_bwd(
         out_state = apply_gate(out_state, gate, values, OperationType.DAGGER)
         if isinstance(gate, Parametric):
             mu = apply_gate(out_state, gate, values, OperationType.JACOBIAN)
-            grads[gate.param] = tangent * 2 * inner(mu, projected_state).real
+            grads[gate.param_name] = tangent * 2 * inner(mu, projected_state).real
         projected_state = apply_gate(projected_state, gate, values, OperationType.DAGGER)
     return (None, None, None, grads)
 

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -96,13 +96,6 @@ def expectation(
     elif diff_mode == DiffMode.ADJOINT:
         return adjoint_expectation(state, gates, observables, values)
     elif diff_mode == DiffMode.GPSR:
-        checkify.check(
-            forward_mode == ForwardMode.SHOTS, "Finite shots and GPSR must be used together"
-        )
-        checkify.check(
-            type(n_shots) is int,
-            "Number of shots must be an integer for finite shots.",
-        )
         # Type checking is disabled because mypy doesn't parse checkify.check.
         # type: ignore
         return finite_shots_fwd(state, gates, observables, values, n_shots=n_shots, key=key)

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -6,7 +6,6 @@ from typing import Any, Optional
 import jax
 import jax.numpy as jnp
 from jax import Array
-from jax.experimental import checkify
 
 from horqrux.adjoint import adjoint_expectation
 from horqrux.apply import apply_gate

--- a/horqrux/circuit.py
+++ b/horqrux/circuit.py
@@ -34,7 +34,7 @@ class Circuit:
 
     @property
     def param_names(self) -> list[str]:
-        return [str(op.param) for op in self.ansatz if isinstance(op, Parametric)]
+        return [str(op.param_name) for op in self.ansatz if isinstance(op, Parametric)]
 
     @property
     def n_vparams(self) -> int:
@@ -61,7 +61,7 @@ def hea(n_qubits: int, n_layers: int, rot_fns: list[Callable] = [RX, RY, RX]) ->
                 fn(str(uuid4()), qubit)
                 for fn, qubit in zip(rot_fns, [i for _ in range(len(rot_fns))])
             ]
-            param_names += [op.param for op in ops]
+            param_names += [op.param_name for op in ops]
             ops += [NOT((i + 1) % n_qubits, i % n_qubits) for i in range(n_qubits)]  # type: ignore[arg-type]
             gates += ops
 

--- a/horqrux/parametric.py
+++ b/horqrux/parametric.py
@@ -34,27 +34,32 @@ class Parametric(Primitive):
     def __post_init__(self) -> None:
         super().__post_init__()
 
-        def parse_dict(self, values: dict[str, float] = dict()) -> float:
+        def parse_dict(self: Parametric, values: dict[str, float] = dict()) -> float:
             return values[self.param_name] + self.shift  # type: ignore[index]
 
-        def parse_val(self, values: dict[str, float] = dict()) -> float:
+        def parse_val(self: Parametric, values: dict[str, float] = dict()) -> float:
             return self.param_val + self.shift  # type: ignore[return-value]
 
         self.parse_values = parse_val if self.param_name is None else parse_dict
 
-    # type: ignore[override]
-    def tree_flatten(self) -> Tuple[Tuple, Tuple[str, Tuple, Tuple, str | float, float]]:
+    def tree_flatten(  # type: ignore[override]
+        self,
+    ) -> Tuple[Tuple[float, float], Tuple[str, Tuple, Tuple, str | None]]:
         children = (self.param_val, self.shift)
-        aux_data = (
-            self.generator_name,
-            self.target[0],
-            self.control[0],
-            self.param_name
-        )
+        aux_data = (self.generator_name, self.target[0], self.control[0], self.param_name)
         return (children, aux_data)
 
     def __iter__(self) -> Iterable:
-        return iter((self.generator_name, self.target, self.control, self.param_name, self.param_val, self.shift))
+        return iter(
+            (
+                self.generator_name,
+                self.target,
+                self.control,
+                self.param_name,
+                self.param_val,
+                self.shift,
+            )
+        )
 
     @classmethod
     def tree_unflatten(cls, aux_data: Any, children: Any) -> Any:
@@ -64,7 +69,7 @@ class Parametric(Primitive):
         return _unitary(OPERATIONS_DICT[self.generator_name], self.parse_values(self, values))
 
     def jacobian(self, values: dict[str, float] = dict()) -> Array:
-        return _jacobian(OPERATIONS_DICT[self.generator_name], self.parse_values(values))
+        return _jacobian(OPERATIONS_DICT[self.generator_name], self.parse_values(self, values))
 
     @property
     def name(self) -> str:
@@ -73,11 +78,15 @@ class Parametric(Primitive):
 
     def __repr__(self) -> str:
         return (
-            self.name +
-            f"(target={self.target[0]}, control={self.control[0]}, param_name={self.param_name}, param_val={self.param_val}, shift={self.shift})"
+            self.name
+            + f"(target={self.target[0]},"
+            + f"control={self.control[0]},"
+            + f"param_name={self.param_name},"
+            + f"param_val={self.param_val},"
+            + f"shift={self.shift})"
         )
 
-    def set_shift(self, shift):
+    def set_shift(self, shift: float) -> None:
         self.shift = shift
 
 
@@ -109,7 +118,9 @@ def RY(param: float | str, target: TargetQubits, control: ControlQubits = (None,
     Returns:
         Parametric: A Parametric gate object.
     """
-    return Parametric("Y", target, control, param)
+    if isinstance(param, str):
+        return Parametric("Y", target, control, param_name=param)
+    return Parametric("Y", target, control, param_val=param)
 
 
 def RZ(param: float | str, target: TargetQubits, control: ControlQubits = (None,)) -> Parametric:
@@ -123,27 +134,29 @@ def RZ(param: float | str, target: TargetQubits, control: ControlQubits = (None,
     Returns:
         Parametric: A Parametric gate object.
     """
-    return Parametric("Z", target, control, param)
+    if isinstance(param, str):
+        return Parametric("Z", target, control, param_name=param)
+    return Parametric("Z", target, control, param_val=param)
 
 
 class _PHASE(Parametric):
     def unitary(self, values: dict[str, float] = dict()) -> Array:
         u = jnp.eye(2, 2, dtype=jnp.complex128)
-        u = u.at[(1, 1)].set(jnp.exp(1.0j * self.parse_values(values)))
+        u = u.at[(1, 1)].set(jnp.exp(1.0j * self.parse_values(self, values)))
         return u
 
     def jacobian(self, values: dict[str, float] = dict()) -> Array:
         jac = jnp.zeros((2, 2), dtype=jnp.complex128)
-        jac = jac.at[(1, 1)].set(1j * jnp.exp(1.0j * self.parse_values(values)))
+        jac = jac.at[(1, 1)].set(1j * jnp.exp(1.0j * self.parse_values(self, values)))
         return jac
 
-    @ property
+    @property
     def name(self) -> str:
         base_name = "PHASE"
         return "C" + base_name if is_controlled(self.control) else base_name
 
 
-def PHASE(param: float, target: TargetQubits, control: ControlQubits = (None,)) -> Parametric:
+def PHASE(param: float | str, target: TargetQubits, control: ControlQubits = (None,)) -> Parametric:
     """Phase gate.
 
     Arguments:
@@ -154,5 +167,6 @@ def PHASE(param: float, target: TargetQubits, control: ControlQubits = (None,)) 
     Returns:
         Parametric: A Parametric gate object.
     """
-
-    return _PHASE("I", target, control, param)
+    if isinstance(param, str):
+        return _PHASE("I", target, control, param_name=param)
+    return _PHASE("I", target, control, param_val=param)

--- a/horqrux/parametric.py
+++ b/horqrux/parametric.py
@@ -44,7 +44,7 @@ class Parametric(Primitive):
 
     def tree_flatten(  # type: ignore[override]
         self,
-    ) -> Tuple[Tuple[float, float], Tuple[str, Tuple, Tuple, str | None]]:
+    ) -> tuple[tuple[float, float], tuple[str, tuple, tuple, str | None]]:
         children = (self.param_val, self.shift)
         aux_data = (self.generator_name, self.target[0], self.control[0], self.param_name)
         return (children, aux_data)

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -1,8 +1,9 @@
 from __future__ import annotations
 
+import functools
+
 import jax
 import jax.numpy as jnp
-import functools
 
 from horqrux import expectation, random_state
 from horqrux.parametric import RX
@@ -32,10 +33,11 @@ def test_shots() -> None:
 
     assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
 
-    d_expect = jax.jit(jax.grad(lambda x, y, z: expect(
-        x, y, z).sum(), argnums=[0, 1]), static_argnums=2)
+    d_expect = jax.jit(
+        jax.grad(lambda x, y, z: expect(x, y, z).sum(), argnums=[0, 1]), static_argnums=2
+    )
 
     grad_backprop = jnp.stack(d_expect(x, y, "exact"))
     grad_shots = jnp.stack(d_expect(x, y, "shots"))
 
-    assert jnp.isclose(grad_backprop, grad_shots, atol=SHOTS_ATOL)
+    assert jnp.allclose(grad_backprop, grad_shots, atol=SHOTS_ATOL)


### PR DESCRIPTION
The previous PR (https://github.com/pasqal-io/horqrux/pull/27) implements the parameter shift rule (PSR) for parameters defined in the `values` argument of expectations. However, it suffered from some limitations:
- It did not allow for the PSR for every parameter: parameters had to be defined via `values`, and a user couldn't pass a parameter directly into a gate.
- It has a bug (https://github.com/pasqal-io/horqrux/issues/29) for repeated values.

This MR addresses the two above points. It also adds tests that the above can be jit-compiled and give the correct answers.

Some noteworthy points:
- When jitting functions containing `checkify.check` points, the output type of the original function is changed to `(error, output_of_original_function)`. This is not ideal for end users, so this has been removed. It would be great to have such checks in the code, so an issue investigating a promising alternative has been raised (https://github.com/pasqal-io/horqrux/issues/30).
- Previously, the `param` attribute of a `Parametric` gate could be of type `str | float`. This was problematic when implementing custom JVP rules, since a `float` is a valid jax type, but a string is not (e.g. https://github.com/google/jax/issues/3045). Consequently, `param` has been explicitly split into `param_name: str` and `param_val: float`, so that `param_val` is always a valid jax type.

Closes #29 