### PR TITLE
[Feature] Adding digital noise

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 [![License](https://img.shields.io/badge/License-Apache_2.0-blue.svg)](https://opensource.org/licenses/Apache-2.0)
 [![Pypi](https://badge.fury.io/py/horqrux.svg)](https://pypi.org/project/horqrux/)
 
-`horqrux` is a [JAX](https://jax.readthedocs.io/en/latest/)-based state vector simulator designed for quantum machine learning and acts as a backend for [`Qadence`](https://github.com/pasqal-io/qadence), a digital-analog quantum programming interface.
+`horqrux` is a [JAX](https://jax.readthedocs.io/en/latest/)-based state vector and density matrix simulator designed for quantum machine learning and acts as a backend for [`Qadence`](https://github.com/pasqal-io/qadence), a digital-analog quantum programming interface.
 
 ## Installation
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -110,10 +110,11 @@ from operator import add
 from typing import Any, Callable
 from uuid import uuid4
 
-from horqrux.circuit import QuantumCircuit, hea, expectation
+from horqrux import expectation
+from horqrux import Z, RX, RY, NOT, zero_state, apply_gate
+from horqrux.circuit import QuantumCircuit, hea
 from horqrux.primitive import Primitive
 from horqrux.parametric import Parametric
-from horqrux import Z, RX, RY, NOT, zero_state, apply_gate
 from horqrux.utils import DiffMode
 
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Welcome to horqrux
 
-**horqrux** is a state vector simulator designed for quantum machine learning written in [JAX](https://jax.readthedocs.io/).
+**horqrux** is a state vector and density matrix simulator designed for quantum machine learning written in [JAX](https://jax.readthedocs.io/).
 
 ## Setup
 

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -17,7 +17,7 @@ $$
 S(\rho) = \sum_i K_i \rho K^{\dagger}_i
 $$
 
-Where $K_i$ are the Kraus operators, and satisfy the property $\sum_i K_i K^{\dagger}_i = \mathbb{I}$. As noise is the result of system interactions with its environment, it is therefore possible to simulate noisy quantum circuit with noise type gates.
+Where $K_i$ are Kraus operators satisfying the closure property $\sum_i K_i K^{\dagger}_i = \mathbb{I}$. As noise is the result of system interactions with its environment, it is therefore possible to simulate noisy quantum circuit with noise type gates.
 
 Thus, `horqrux` implements a large selection of single qubit noise gates such as:
 

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -10,7 +10,7 @@ $$
 \rho = \sum_i p_i |\psi_i\rangle \langle \psi_i|
 $$
 
-The transformations of the density operator of an open quantum system interacting with its environment (noise) are represented by the super-operator $S: \rho \rightarrow S(\rho)$, often referred to as a quantum channel.
+The transformations of the density operator of an open quantum system interacting with its noisy environment are represented by the super-operator $S: \rho \rightarrow S(\rho)$, often referred to as a quantum channel.
 Quantum channels, due to the conservation of the probability distribution, must be CPTP (Completely Positive and Trace Preserving). Any CPTP super-operator can be written in the following form:
 
 $$

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -1,0 +1,101 @@
+## Digital Noise
+
+In the description of closed quantum systems, a pure state vector is used to represent the complete quantum state. Thus, pure quantum states are represented by state vectors $|\psi \rangle $.
+
+However, this description is not sufficient to study open quantum systems. When the system interacts with its environment, quantum systems can be in a mixed state, where quantum information is no longer entirely contained in a single state vector but is distributed probabilistically.
+
+To address these more general cases, we consider a probabilistic combination $p_i$ of possible pure states $|\psi_i \rangle$. Thus, the system is described by a density matrix $\rho$ defined as follows:
+
+$$
+\rho = \sum_i p_i |\psi_i\rangle \langle \psi_i|
+$$
+
+The transformations of the density operator of an open quantum system interacting with its environment (noise) are represented by the super-operator $S: \rho \rightarrow S(\rho)$, often referred to as a quantum channel.
+Quantum channels, due to the conservation of the probability distribution, must be CPTP (Completely Positive and Trace Preserving). Any CPTP super-operator can be written in the following form:
+
+$$
+S(\rho) = \sum_i K_i \rho K^{\dagger}_i
+$$
+
+Where $K_i$ are the Kraus operators, and satisfy the property $\sum_i K_i K^{\dagger}_i = \mathbb{I}$. As noise is the result of system interactions with its environment, it is therefore possible to simulate noisy quantum circuit with noise type gates.
+
+Thus, `horqrux` implements a large selection of single qubit noise gates such as:
+
+- The bit flip channel defined as: $\textbf{BitFlip}(\rho) =(1-p) \rho + p X \rho X^{\dagger}$
+- The phase flip channel defined as: $\textbf{PhaseFlip}(\rho) = (1-p) \rho + p Z \rho Z^{\dagger}$
+- The depolarizing channel defined as: $\textbf{Depolarizing}(\rho) = (1-p) \rho + \frac{p}{3} (X \rho X^{\dagger} + Y \rho Y^{\dagger} + Z \rho Z^{\dagger})$
+- The pauli channel defined as: $\textbf{PauliChannel}(\rho) = (1-p_x-p_y-p_z) \rho
+            + p_x X \rho X^{\dagger}
+            + p_y Y \rho Y^{\dagger}
+            + p_z Z \rho Z^{\dagger}$
+- The amplitude damping channel defined as: $\textbf{AmplitudeDamping}(\rho) =  K_0 \rho K_0^{\dagger} + K_1 \rho K_1^{\dagger}$
+    with:
+    $\begin{equation*}
+    K_{0} \ =\begin{pmatrix}
+    1 & 0\\
+    0 & \sqrt{1-\ \gamma }
+    \end{pmatrix} ,\ K_{1} \ =\begin{pmatrix}
+    0 & \sqrt{\ \gamma }\\
+    0 & 0
+    \end{pmatrix}
+    \end{equation*}$
+- The phase damping channel defined as: $\textbf{PhaseDamping}(\rho) = K_0 \rho K_0^{\dagger} + K_1 \rho K_1^{\dagger}$
+    with:
+    $\begin{equation*}
+    K_{0} \ =\begin{pmatrix}
+    1 & 0\\
+    0 & \sqrt{1-\ \gamma }
+    \end{pmatrix}, \ K_{1} \ =\begin{pmatrix}
+    0 & 0\\
+    0 & \sqrt{\ \gamma }
+    \end{pmatrix}
+    \end{equation*}$
+* The generalize amplitude damping channel is defined as: $\textbf{GeneralizedAmplitudeDamping}(\rho) = K_0 \rho K_0^{\dagger} + K_1 \rho K_1^{\dagger} + K_2 \rho K_2^{\dagger} + K_3 \rho K_3^{\dagger}$
+    with:
+$\begin{cases}
+K_{0} \ =\sqrt{p} \ \begin{pmatrix}
+1 & 0\\
+0 & \sqrt{1-\ \gamma }
+\end{pmatrix} ,\ K_{1} \ =\sqrt{p} \ \begin{pmatrix}
+0 & 0\\
+0 & \sqrt{\ \gamma }
+\end{pmatrix} \\
+K_{2} \ =\sqrt{1\ -p} \ \begin{pmatrix}
+\sqrt{1-\ \gamma } & 0\\
+0 & 1
+\end{pmatrix} ,\ K_{3} \ =\sqrt{1-p} \ \begin{pmatrix}
+0 & 0\\
+\sqrt{\ \gamma } & 0
+\end{pmatrix}
+\end{cases}$
+
+Noise protocols can be added to gates by instantiating `NoiseInstance` providing the `NoiseType` and the `error_probability` (either float or tuple of float):
+
+```python exec="on" source="material-block" html="1"
+from horqrux.noise import NoiseInstance, NoiseType
+
+noise_prob = 0.3
+AmpD = NoiseInstance(NoiseType.AMPLITUDE_DAMPING, error_probability=noise_prob)
+
+```
+
+Then a gate can be instantiated by providing a tuple of `NoiseInstance` instances. Let’s show this through the simulation of a realistic $X$ gate. 
+
+We know that an $X$ gate flips the state of the qubit, for instance $X|0\rangle = |1\rangle$. In practice, it's common for the target qubit to stay in its original state after applying $X$ due to the interactions between it and its environment. The possibility of failure can be represented by a `BitFlip` `NoiseInstance`, which flips the state again after the application of the $X$ gate, returning it to its original state with a probability `1 - gate_fidelity`.
+
+```python exec="on" source="material-block"
+from horqrux.api import sample
+from horqrux.noise import NoiseInstance, NoiseType
+from horqrux.utils import density_mat, product_state
+from horqrux.primitive import X
+
+noise = (NoiseInstance(NoiseType.BITFLIP, 0.1),)
+ops = [X(0)]
+noisy_ops = [X(0, noise=noise)]
+state = product_state("0")
+
+noiseless_samples = sample(state, ops)
+noisy_samples = sample(density_mat(state), noisy_ops, is_state_densitymat=True)
+print("Noiseless samples", noiseless_samples) # markdown-exec: hide
+print("Noiseless samples", noisy_samples) # markdown-exec: hide
+```

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -79,7 +79,7 @@ AmpD = NoiseInstance(NoiseType.AMPLITUDE_DAMPING, error_probability=noise_prob)
 
 ```
 
-Then a gate can be instantiated by providing a tuple of `NoiseInstance` instances. Let’s show this through the simulation of a realistic $X$ gate. 
+Then a gate can be instantiated by providing a tuple of `NoiseInstance` instances. Let’s show this through the simulation of a realistic $X$ gate.
 
 We know that an $X$ gate flips the state of the qubit, for instance $X|0\rangle = |1\rangle$. In practice, it's common for the target qubit to stay in its original state after applying $X$ due to the interactions between it and its environment. The possibility of failure can be represented by a `BitFlip` `NoiseInstance`, which flips the state again after the application of the $X$ gate, returning it to its original state with a probability `1 - gate_fidelity`.
 

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -96,6 +96,6 @@ state = product_state("0")
 
 noiseless_samples = sample(state, ops)
 noisy_samples = sample(density_mat(state), noisy_ops)
-print("Noiseless samples", noiseless_samples) # markdown-exec: hide
-print("Noiseless samples", noisy_samples) # markdown-exec: hide
+print(f"Noiseless samples: {noiseless_samples}") # markdown-exec: hide
+print(f"Noiseless samples: {noisy_samples}") # markdown-exec: hide
 ```

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -1,6 +1,6 @@
 ## Digital Noise
 
-In the description of closed quantum systems, a pure state vector is used to represent the complete quantum state. Thus, pure quantum states are represented by state vectors $|\psi \rangle $.
+In the description of closed quantum systems, the complete quantum state is a pure quantum state represented by a state vector $|\psi \rangle $.
 
 However, this description is not sufficient to study open quantum systems. When the system interacts with its environment, quantum systems can be in a mixed state, where quantum information is no longer entirely contained in a single state vector but is distributed probabilistically.
 

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -95,7 +95,7 @@ noisy_ops = [X(0, noise=noise)]
 state = product_state("0")
 
 noiseless_samples = sample(state, ops)
-noisy_samples = sample(density_mat(state), noisy_ops, is_density=True)
+noisy_samples = sample(density_mat(state), noisy_ops)
 print("Noiseless samples", noiseless_samples) # markdown-exec: hide
 print("Noiseless samples", noisy_samples) # markdown-exec: hide
 ```

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -2,7 +2,7 @@
 
 In the description of closed quantum systems, the complete quantum state is a pure quantum state represented by a state vector $|\psi \rangle $.
 
-However, this description is not sufficient to study open quantum systems. When the system interacts with its environment, quantum systems can be in a mixed state, where quantum information is no longer entirely contained in a single state vector but is distributed probabilistically.
+However, this description is not sufficient to describe open quantum systems. When the system interacts with its surrounding environment, it transitions into a mixed state where quantum information is no longer entirely contained in a single state vector but is distributed probabilistically.
 
 To address these more general cases, we consider a probabilistic combination $p_i$ of possible pure states $|\psi_i \rangle$. Thus, the system is described by a density matrix $\rho$ defined as follows:
 

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -95,7 +95,7 @@ noisy_ops = [X(0, noise=noise)]
 state = product_state("0")
 
 noiseless_samples = sample(state, ops)
-noisy_samples = sample(density_mat(state), noisy_ops, is_state_densitymat=True)
+noisy_samples = sample(density_mat(state), noisy_ops, is_density=True)
 print("Noiseless samples", noiseless_samples) # markdown-exec: hide
 print("Noiseless samples", noisy_samples) # markdown-exec: hide
 ```

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -69,27 +69,27 @@ K_{2} \ =\sqrt{1\ -p} \ \begin{pmatrix}
 \end{pmatrix}
 \end{cases}$
 
-Noise protocols can be added to gates by instantiating `NoiseInstance` providing the `NoiseType` and the `error_probability` (either float or tuple of float):
+Noise protocols can be added to gates by instantiating `DigitalNoiseInstance` providing the `DigitalNoiseType` and the `error_probability` (either float or tuple of float):
 
 ```python exec="on" source="material-block" html="1"
-from horqrux.noise import NoiseInstance, NoiseType
+from horqrux.noise import DigitalNoiseInstance, DigitalNoiseType
 
 noise_prob = 0.3
-AmpD = NoiseInstance(NoiseType.AMPLITUDE_DAMPING, error_probability=noise_prob)
+AmpD = DigitalNoiseInstance(DigitalNoiseType.AMPLITUDE_DAMPING, error_probability=noise_prob)
 
 ```
 
-Then a gate can be instantiated by providing a tuple of `NoiseInstance` instances. Let’s show this through the simulation of a realistic $X$ gate.
+Then a gate can be instantiated by providing a tuple of `DigitalNoiseInstance` instances. Let’s show this through the simulation of a realistic $X$ gate.
 
-For instance, an $X$ gate flips the state of the qubit: $X|0\rangle = |1\rangle$. In practice, it's common for the target qubit to stay in its original state after applying $X$ due to the interactions between it and its environment. The possibility of failure can be represented by the `BitFlip` subclass of `NoiseInstance`, which flips the state again after the application of the $X$ gate, returning it to its original state with a probability `1 - gate_fidelity`.
+For instance, an $X$ gate flips the state of the qubit: $X|0\rangle = |1\rangle$. In practice, it's common for the target qubit to stay in its original state after applying $X$ due to the interactions between it and its environment. The possibility of failure can be represented by the `BitFlip` subclass of `DigitalNoiseInstance`, which flips the state again after the application of the $X$ gate, returning it to its original state with a probability `1 - gate_fidelity`.
 
 ```python exec="on" source="material-block"
 from horqrux.api import sample
-from horqrux.noise import NoiseInstance, NoiseType
+from horqrux.noise import DigitalNoiseInstance, DigitalNoiseType
 from horqrux.utils import density_mat, product_state
 from horqrux.primitive import X
 
-noise = (NoiseInstance(NoiseType.BITFLIP, 0.1),)
+noise = (DigitalNoiseInstance(DigitalNoiseType.BITFLIP, 0.1),)
 ops = [X(0)]
 noisy_ops = [X(0, noise=noise)]
 state = product_state("0")

--- a/docs/noise.md
+++ b/docs/noise.md
@@ -81,7 +81,7 @@ AmpD = NoiseInstance(NoiseType.AMPLITUDE_DAMPING, error_probability=noise_prob)
 
 Then a gate can be instantiated by providing a tuple of `NoiseInstance` instances. Let’s show this through the simulation of a realistic $X$ gate.
 
-We know that an $X$ gate flips the state of the qubit, for instance $X|0\rangle = |1\rangle$. In practice, it's common for the target qubit to stay in its original state after applying $X$ due to the interactions between it and its environment. The possibility of failure can be represented by a `BitFlip` `NoiseInstance`, which flips the state again after the application of the $X$ gate, returning it to its original state with a probability `1 - gate_fidelity`.
+For instance, an $X$ gate flips the state of the qubit: $X|0\rangle = |1\rangle$. In practice, it's common for the target qubit to stay in its original state after applying $X$ due to the interactions between it and its environment. The possibility of failure can be represented by the `BitFlip` subclass of `NoiseInstance`, which flips the state again after the application of the $X$ gate, returning it to its original state with a probability `1 - gate_fidelity`.
 
 ```python exec="on" source="material-block"
 from horqrux.api import sample

--- a/horqrux/__init__.py
+++ b/horqrux/__init__.py
@@ -1,8 +1,8 @@
 from __future__ import annotations
 
-from .api import expectation, run
+from .api import expectation, run, sample
 from .apply import apply_gate, apply_operator
-from .circuit import QuantumCircuit, sample
+from .circuit import QuantumCircuit
 from .parametric import PHASE, RX, RY, RZ
 from .primitive import NOT, SWAP, H, I, S, T, X, Y, Z
 from .utils import (

--- a/horqrux/__init__.py
+++ b/horqrux/__init__.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from .api import expectation
+from .api import expectation, run
 from .apply import apply_gate, apply_operator
 from .circuit import QuantumCircuit, sample
 from .parametric import PHASE, RX, RY, RZ

--- a/horqrux/adjoint.py
+++ b/horqrux/adjoint.py
@@ -1,7 +1,5 @@
 from __future__ import annotations
 
-from typing import Tuple
-
 from jax import Array, custom_vjp
 
 from horqrux.apply import apply_gate
@@ -37,14 +35,14 @@ def adjoint_expectation(
 
 def adjoint_expectation_single_observable_fwd(
     state: Array, gates: list[Primitive], observable: list[Primitive], values: dict[str, float]
-) -> Tuple[Array, Tuple[Array, Array, list[Primitive], dict[str, float]]]:
+) -> tuple[Array, tuple[Array, Array, list[Primitive], dict[str, float]]]:
     out_state = apply_gate(state, gates, values, OperationType.UNITARY)
     projected_state = apply_gate(out_state, observable, values, OperationType.UNITARY)
     return inner(out_state, projected_state).real, (out_state, projected_state, gates, values)
 
 
 def adjoint_expectation_single_observable_bwd(
-    res: Tuple[Array, Array, list[Primitive], dict[str, float]], tangent: Array
+    res: tuple[Array, Array, list[Primitive], dict[str, float]], tangent: Array
 ) -> tuple:
     """Implementation of Algorithm 1 of https://arxiv.org/abs/2009.02823
     which computes the vector-jacobian product in O(P) time using O(1) state vectors

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -13,7 +13,15 @@ from horqrux.adjoint import adjoint_expectation
 from horqrux.apply import apply_gate
 from horqrux.primitive import GateSequence, Primitive
 from horqrux.shots import finite_shots_fwd, observable_to_matrix
-from horqrux.utils import DensityMatrix, DiffMode, ForwardMode, OperationType, inner
+from horqrux.utils import (
+    DensityMatrix,
+    DiffMode,
+    ForwardMode,
+    OperationType,
+    get_probas,
+    inner,
+    sample_from_probs,
+)
 
 
 def run(
@@ -24,91 +32,61 @@ def run(
     return apply_gate(state, circuit, values)
 
 
-def sample_from_probs(probs: Array, n_qubits: int, n_shots: int) -> Counter:
-    key = jax.random.PRNGKey(0)
+def sample(
+    state: Array | DensityMatrix,
+    gates: GateSequence,
+    values: dict[str, float] = dict(),
+    n_shots: int = 1000,
+) -> Counter:
+    if n_shots < 1:
+        raise ValueError("You can only call sample with n_shots>0.")
+    output_circuit = apply_gate(state, gates, values)
 
-    # JAX handles pseudo random number generation by tracking an explicit state via a random key
-    # For more details, see https://jax.readthedocs.io/en/latest/random-numbers.html
-    samples = jax.vmap(
-        lambda subkey: jax.random.choice(key=subkey, a=jnp.arange(0, 2**n_qubits), p=probs)
-    )(jax.random.split(key, n_shots))
+    if isinstance(output_circuit, DensityMatrix):
+        n_qubits = len(output_circuit.array.shape) // 2
+        d = 2**n_qubits
+        output_circuit.array = output_circuit.array.reshape((d, d))
+    else:
+        n_qubits = len(output_circuit.array.shape)
 
-    return Counter(
-        {
-            format(k, "0{}b".format(n_qubits)): count.item()
-            for k, count in enumerate(jnp.bincount(samples))
-            if count > 0
-        }
-    )
+    probs = get_probas(output_circuit)
+    return sample_from_probs(probs, n_qubits, n_shots)
 
 
 @singledispatch
-def sample(
-    state: Array,
-    gates: GateSequence,
-    values: dict[str, float] = dict(),
-    n_shots: int = 1000,
-) -> Counter:
-    raise NotImplementedError("sample method is not implemented")
-
-
-@sample.register
-def _(
-    state: Array,
-    gates: GateSequence,
-    values: dict[str, float] = dict(),
-    n_shots: int = 1000,
-) -> Counter:
-    if n_shots < 1:
-        raise ValueError("You can only call sample with n_shots>0.")
-
-    output_circuit = apply_gate(state, gates, values)
-    n_qubits = len(state.shape)
-    probs = jnp.abs(jnp.float_power(output_circuit, 2.0)).ravel()
-    return sample_from_probs(probs, n_qubits, n_shots)
-
-
-@sample.register
-def _(
-    state: DensityMatrix,
-    gates: GateSequence,
-    values: dict[str, float] = dict(),
-    n_shots: int = 1000,
-) -> Counter:
-    if n_shots < 1:
-        raise ValueError("You can only call sample with n_shots>0.")
-
-    output_circuit = apply_gate(state, gates, values)
-    n_qubits = len(state.array.shape) // 2
-    d = 2**n_qubits
-    probs = jnp.diagonal(output_circuit.array.reshape((d, d))).real
-    return sample_from_probs(probs, n_qubits, n_shots)
-
-
 def __ad_expectation_single_observable(
-    state: Array | DensityMatrix,
-    gates: GateSequence,
+    output_state: Array,
     observable: Primitive,
     values: dict[str, float],
 ) -> Array:
-    """
-    Run 'state' through a sequence of 'gates' given parameters 'values'
-    and compute the expectation given an observable.
-    """
-    out_state = apply_gate(state, gates, values, OperationType.UNITARY)
+    raise NotImplementedError("__ad_expectation_single_observable is not implemented")
 
-    if not isinstance(out_state, DensityMatrix):
-        projected_state = apply_gate(
-            out_state,
-            observable,
-            values,
-            OperationType.UNITARY,
-        )
-        return inner(out_state, projected_state).real
-    n_qubits = len(out_state.array.shape) // 2
+
+@__ad_expectation_single_observable.register
+def _(
+    state: Array,
+    observable: Primitive,
+    values: dict[str, float],
+) -> Array:
+    projected_state = apply_gate(
+        state,
+        observable,
+        values,
+        OperationType.UNITARY,
+    )
+    return inner(state, projected_state).real
+
+
+@__ad_expectation_single_observable.register
+def _(
+    state: DensityMatrix,
+    observable: Primitive,
+    values: dict[str, float],
+) -> Array:
+    n_qubits = len(state.array.shape) // 2
     mat_obs = observable_to_matrix(observable, n_qubits)
     d = 2**n_qubits
-    prod = jnp.matmul(mat_obs, out_state.array.reshape((d, d)))
+    prod = jnp.matmul(mat_obs, state.array.reshape((d, d)))
     return jnp.trace(prod, axis1=-2, axis2=-1).real
 
 
@@ -123,7 +101,9 @@ def ad_expectation(
     and compute the expectation given an observable.
     """
     outputs = [
-        __ad_expectation_single_observable(state, gates, observable, values)
+        __ad_expectation_single_observable(
+            apply_gate(state, gates, values, OperationType.UNITARY), observable, values
+        )
         for observable in observables
     ]
     return jnp.stack(outputs)

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -34,13 +34,16 @@ def sample(
     if n_shots < 1:
         raise ValueError("You can only call sample with n_shots>0.")
 
+    output_circuit = apply_gate(state, gates, values, is_state_densitymat=is_state_densitymat)
     if is_state_densitymat:
-        raise NotImplementedError("Sampling with density matrices is not yet supported!")
-
-    wf = apply_gate(state, gates, values)
-    probs = jnp.abs(jnp.float_power(wf, 2.0)).ravel()
+        n_qubits = len(state.shape) // 2
+        d = 2**n_qubits
+        probs = jnp.diagonal(output_circuit.reshape((d, d))).real
+    else:
+        n_qubits = len(state.shape)
+        probs = jnp.abs(jnp.float_power(output_circuit, 2.0)).ravel()
     key = jax.random.PRNGKey(0)
-    n_qubits = len(state.shape)
+
     # JAX handles pseudo random number generation by tracking an explicit state via a random key
     # For more details, see https://jax.readthedocs.io/en/latest/random-numbers.html
     samples = jax.vmap(

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -28,9 +28,13 @@ def sample(
     gates: GateSequence,
     values: dict[str, float] = dict(),
     n_shots: int = 1000,
+    is_state_densitymat: bool = False,
 ) -> Counter:
     if n_shots < 1:
         raise ValueError("You can only call sample with n_shots>0.")
+
+    if is_state_densitymat:
+        raise NotImplementedError("Sampling with density matrices is not yet supported!")
 
     wf = apply_gate(state, gates, values)
     probs = jnp.abs(jnp.float_power(wf, 2.0)).ravel()
@@ -119,4 +123,12 @@ def expectation(
         # type: ignore
         if is_state_densitymat:
             raise NotImplementedError("Expectation from density matrices is not yet supported!")
-        return finite_shots_fwd(state, gates, observables, values, n_shots=n_shots, key=key)
+        return finite_shots_fwd(
+            state,
+            gates,
+            observables,
+            values,
+            n_shots=n_shots,
+            is_state_densitymat=is_state_densitymat,
+            key=key,
+        )

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -73,7 +73,7 @@ def __ad_expectation_single_observable(
     state: Any,
     observable: Primitive,
     values: dict[str, float],
-) -> Array:
+) -> Any:
     raise NotImplementedError("__ad_expectation_single_observable is not implemented")
 
 

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -20,6 +20,7 @@ from horqrux.utils import (
     OperationType,
     State,
     inner,
+    num_qubits,
     probabilities,
     sample_from_probs,
 )
@@ -56,13 +57,10 @@ def sample(
     if n_shots < 1:
         raise ValueError("You can only sample with non-negative 'n_shots'.")
     output_circuit = apply_gate(state, gates, values)
-
+    n_qubits = num_qubits(output_circuit)
     if isinstance(output_circuit, DensityMatrix):
-        n_qubits = len(output_circuit.array.shape) // 2
         d = 2**n_qubits
         output_circuit.array = output_circuit.array.reshape((d, d))
-    else:
-        n_qubits = len(output_circuit.shape)
 
     probs = probabilities(output_circuit)
     return sample_from_probs(probs, n_qubits, n_shots)
@@ -98,7 +96,7 @@ def _(
     observable: Primitive,
     values: dict[str, float],
 ) -> Array:
-    n_qubits = len(state.array.shape) // 2
+    n_qubits = num_qubits(state)
     mat_obs = to_matrix(observable, n_qubits, values)
     d = 2**n_qubits
     prod = jnp.matmul(mat_obs, state.array.reshape((d, d)))

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -52,7 +52,11 @@ def sample(
 
 
 def __ad_expectation_single_observable(
-    state: Array, gates: GateSequence, observable: Primitive, values: dict[str, float]
+    state: Array,
+    gates: GateSequence,
+    observable: Primitive,
+    values: dict[str, float],
+    is_state_densitymat: bool = False,
 ) -> Array:
     """
     Run 'state' through a sequence of 'gates' given parameters 'values'
@@ -60,11 +64,18 @@ def __ad_expectation_single_observable(
     """
     out_state = apply_gate(state, gates, values, OperationType.UNITARY)
     projected_state = apply_gate(out_state, observable, values, OperationType.UNITARY)
-    return inner(out_state, projected_state).real
+    if not is_state_densitymat:
+        return inner(out_state, projected_state).real
+
+    raise NotImplementedError("Expectation from density matrices is not yet supported!")
 
 
 def ad_expectation(
-    state: Array, gates: GateSequence, observables: list[Primitive], values: dict[str, float]
+    state: Array,
+    gates: GateSequence,
+    observables: list[Primitive],
+    values: dict[str, float],
+    is_state_densitymat: bool = False,
 ) -> Array:
     """
     Run 'state' through a sequence of 'gates' given parameters 'values'
@@ -85,6 +96,7 @@ def expectation(
     diff_mode: DiffMode = DiffMode.AD,
     forward_mode: ForwardMode = ForwardMode.EXACT,
     n_shots: Optional[int] = None,
+    is_state_densitymat: bool = False,
     key: Any = jax.random.PRNGKey(0),
 ) -> Array:
     """

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -69,15 +69,15 @@ def sample(
 
 
 @singledispatch
-def __ad_expectation_single_observable(
+def _ad_expectation_single_observable(
     state: Any,
     observable: Primitive,
     values: dict[str, float],
 ) -> Any:
-    raise NotImplementedError("__ad_expectation_single_observable is not implemented")
+    raise NotImplementedError("_ad_expectation_single_observable is not implemented")
 
 
-@__ad_expectation_single_observable.register
+@_ad_expectation_single_observable.register
 def _(
     state: Array,
     observable: Primitive,
@@ -92,7 +92,7 @@ def _(
     return inner(state, projected_state).real
 
 
-@__ad_expectation_single_observable.register
+@_ad_expectation_single_observable.register
 def _(
     state: DensityMatrix,
     observable: Primitive,
@@ -124,7 +124,7 @@ def ad_expectation(
         Array: Expectation values.
     """
     outputs = [
-        __ad_expectation_single_observable(
+        _ad_expectation_single_observable(
             apply_gate(state, gates, values, OperationType.UNITARY), observable, values
         )
         for observable in observables

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -82,7 +82,7 @@ def ad_expectation(
     and compute the expectation given an observable.
     """
     outputs = [
-        __ad_expectation_single_observable(state, gates, observable, values)
+        __ad_expectation_single_observable(state, gates, observable, values, is_state_densitymat)
         for observable in observables
     ]
     return jnp.stack(outputs)
@@ -117,4 +117,6 @@ def expectation(
         )
         # Type checking is disabled because mypy doesn't parse checkify.check.
         # type: ignore
+        if is_state_densitymat:
+            raise NotImplementedError("Expectation from density matrices is not yet supported!")
         return finite_shots_fwd(state, gates, observables, values, n_shots=n_shots, key=key)

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -19,8 +19,8 @@ from horqrux.utils import (
     ForwardMode,
     OperationType,
     State,
-    probabilities,
     inner,
+    probabilities,
     sample_from_probs,
 )
 

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -175,10 +175,10 @@ def expectation(
         # Type checking is disabled because mypy doesn't parse checkify.check.
         # type: ignore
         return finite_shots_fwd(
-            state,
-            gates,
-            observables,
-            values,
+            state=state,
+            gates=gates,
+            observables=observables,
+            values=values,
             n_shots=n_shots,
             key=key,
         )

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -84,7 +84,7 @@ def _(
     values: dict[str, float],
 ) -> Array:
     n_qubits = len(state.array.shape) // 2
-    mat_obs = observable_to_matrix(observable, n_qubits)
+    mat_obs = observable_to_matrix(observable, n_qubits, values)
     d = 2**n_qubits
     prod = jnp.matmul(mat_obs, state.array.reshape((d, d)))
     return jnp.trace(prod, axis1=-2, axis2=-1).real

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -54,7 +54,7 @@ def sample(
         Counter: Bitstrings and frequencies.
     """
     if n_shots < 1:
-        raise ValueError("You can only call sample with n_shots>0.")
+        raise ValueError("You can only sample with non-negative 'n_shots'.")
     output_circuit = apply_gate(state, gates, values)
 
     if isinstance(output_circuit, DensityMatrix):

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -62,7 +62,7 @@ def sample(
         d = 2**n_qubits
         output_circuit.array = output_circuit.array.reshape((d, d))
     else:
-        n_qubits = len(output_circuit.array.shape)
+        n_qubits = len(output_circuit.shape)
 
     probs = get_probas(output_circuit)
     return sample_from_probs(probs, n_qubits, n_shots)

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -19,8 +19,9 @@ def run(
     circuit: GateSequence,
     state: Array,
     values: dict[str, float] = dict(),
+    is_state_densitymat: bool = False,
 ) -> Array:
-    return apply_gate(state, circuit, values)
+    return apply_gate(state, circuit, values, is_state_densitymat=is_state_densitymat)
 
 
 def sample(
@@ -121,8 +122,8 @@ def expectation(
         )
         # Type checking is disabled because mypy doesn't parse checkify.check.
         # type: ignore
-        if is_state_densitymat:
-            raise NotImplementedError("Expectation from density matrices is not yet supported!")
+        # if is_state_densitymat:
+        #     raise NotImplementedError("Expectation with density matrices is not yet supported!")
         return finite_shots_fwd(
             state,
             gates,

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -12,14 +12,14 @@ from jax.experimental import checkify
 from horqrux.adjoint import adjoint_expectation
 from horqrux.apply import apply_gate
 from horqrux.primitive import GateSequence, Primitive
-from horqrux.shots import finite_shots_fwd, observable_to_matrix
+from horqrux.shots import finite_shots_fwd, to_matrix
 from horqrux.utils import (
     DensityMatrix,
     DiffMode,
     ForwardMode,
     OperationType,
     State,
-    get_probas,
+    probabilities,
     inner,
     sample_from_probs,
 )
@@ -64,7 +64,7 @@ def sample(
     else:
         n_qubits = len(output_circuit.shape)
 
-    probs = get_probas(output_circuit)
+    probs = probabilities(output_circuit)
     return sample_from_probs(probs, n_qubits, n_shots)
 
 
@@ -99,7 +99,7 @@ def _(
     values: dict[str, float],
 ) -> Array:
     n_qubits = len(state.array.shape) // 2
-    mat_obs = observable_to_matrix(observable, n_qubits, values)
+    mat_obs = to_matrix(observable, n_qubits, values)
     d = 2**n_qubits
     prod = jnp.matmul(mat_obs, state.array.reshape((d, d)))
     return jnp.trace(prod, axis1=-2, axis2=-1).real

--- a/horqrux/api.py
+++ b/horqrux/api.py
@@ -162,7 +162,7 @@ def expectation(
         return ad_expectation(state, gates, observables, values)
     elif diff_mode == DiffMode.ADJOINT:
         if isinstance(state, DensityMatrix):
-            raise ValueError("Adjoint does not support density matrices.")
+            raise TypeError("Adjoint does not support density matrices.")
         return adjoint_expectation(state, gates, observables, values)
     elif diff_mode == DiffMode.GPSR:
         checkify.check(

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -336,7 +336,7 @@ def prepare_sequence_reduce(
 @apply_gate.register
 def _(
     state: Array,
-    gate: Primitive | Iterable[Primitive],
+    gate: Union[Primitive, Iterable[Primitive]],
     values: dict[str, float] = dict(),
     op_type: OperationType = OperationType.UNITARY,
     group_gates: bool = False,  # Defaulting to False since this can be performed once before circuit execution
@@ -380,7 +380,7 @@ def _(
 @apply_gate.register
 def _(
     state: DensityMatrix,
-    gate: Primitive | Iterable[Primitive],
+    gate: Union[Primitive, Iterable[Primitive]],
     values: dict[str, float] = dict(),
     op_type: OperationType = OperationType.UNITARY,
     group_gates: bool = False,  # Defaulting to False since this can be performed once before circuit execution

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -30,7 +30,7 @@ def apply_operator(
     operator: Array,
     target: tuple[int, ...],
     control: tuple[int | None, ...],
-) -> Array:
+) -> Any:
     """Apply an operator on a state or density matrix.
 
     Args:
@@ -288,7 +288,7 @@ def apply_gate(
     op_type: OperationType = OperationType.UNITARY,
     group_gates: bool = False,  # Defaulting to False since this can be performed once before circuit execution
     merge_ops: bool = True,
-) -> State:
+) -> Any:
     raise NotImplementedError("apply_gate is not implemented")
 
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import partial, reduce, singledispatch
 from operator import add
-from typing import Any, Iterable
+from typing import Any, Iterable, Union
 
 import jax
 import jax.numpy as jnp
@@ -29,7 +29,7 @@ def apply_operator(
     state: Any,
     operator: Array,
     target: tuple[int, ...],
-    control: tuple[int | None, ...],
+    control: tuple[Union[int, None], ...],
 ) -> Any:
     """Apply an operator on a state or density matrix.
 
@@ -53,7 +53,7 @@ def _(
     state: Array,
     operator: Array,
     target: tuple[int, ...],
-    control: tuple[int | None, ...],
+    control: tuple[Union[int, None], ...],
 ) -> Array:
     """Applies an operator, i.e. a single array of shape [2, 2, ...], on a given state
        of shape [2 for _ in range(n_qubits)] for a given set of target and control qubits.
@@ -93,7 +93,7 @@ def _(
     state: DensityMatrix,
     operator: Array,
     target: tuple[int, ...],
-    control: tuple[int | None, ...],
+    control: tuple[Union[int, None], ...],
 ) -> DensityMatrix:
     """Applies an operator, i.e. a single array of shape [2, 2, ...], on a given density matrix
        of shape [2 for _ in range(2 * n_qubits)] for a given set of target and control qubits.
@@ -197,7 +197,7 @@ def apply_operator_with_noise(
     state: DensityMatrix,
     operator: Array,
     target: tuple[int, ...],
-    control: tuple[int | None, ...],
+    control: tuple[Union[int, None], ...],
     noise: NoiseProtocol,
 ) -> State:
     """Evolves the input state and applies a noisy quantum channel

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -2,7 +2,7 @@ from __future__ import annotations
 
 from functools import partial, reduce
 from operator import add
-from typing import Iterable, Tuple
+from typing import Iterable
 
 import jax
 import jax.numpy as jnp
@@ -26,8 +26,8 @@ from .utils import (
 def apply_operator(
     state: State,
     operator: Array,
-    target: Tuple[int, ...],
-    control: Tuple[int | None, ...],
+    target: tuple[int, ...],
+    control: tuple[int | None, ...],
 ) -> State:
     """Applies an operator, i.e. a single array of shape [2, 2, ...], on a given state
        of shape [2 for _ in range(n_qubits)] for a given set of target and control qubits.
@@ -43,14 +43,14 @@ def apply_operator(
     Arguments:
         state: State to operate on.
         operator: Array to contract over 'state'.
-        target: Tuple of target qubits on which to apply the 'operator' to.
-        control: Tuple of control qubits.
+        target: tuple of target qubits on which to apply the 'operator' to.
+        control: tuple of control qubits.
         is_density: Whether the state is provided as a density matrix.
 
     Returns:
         State after applying 'operator'.
     """
-    state_dims: Tuple[int, ...] = target
+    state_dims: tuple[int, ...] = target
     if is_controlled(control):
         operator = _controlled(operator, len(control))
         state_dims = (*control, *target)  # type: ignore[arg-type]
@@ -66,8 +66,8 @@ def apply_operator(
 def apply_operator_dm(
     state: State,
     operator: Array,
-    target: Tuple[int, ...],
-    control: Tuple[int | None, ...],
+    target: tuple[int, ...],
+    control: tuple[int | None, ...],
 ) -> State:
     """Applies an operator, i.e. a single array of shape [2, 2, ...], on a given density matrix
        of shape [2 for _ in range(2 * n_qubits)] for a given set of target and control qubits.
@@ -76,14 +76,14 @@ def apply_operator_dm(
     Arguments:
         state: Density matrix to operate on.
         operator: Array to contract over 'state'.
-        target: Tuple of target qubits on which to apply the 'operator' to.
-        control: Tuple of control qubits.
+        target: tuple of target qubits on which to apply the 'operator' to.
+        control: tuple of control qubits.
         is_density: Whether the state is provided as a density matrix.
 
     Returns:
         Density matrix after applying 'operator'.
     """
-    state_dims: Tuple[int, ...] = target
+    state_dims: tuple[int, ...] = target
     if is_controlled(control):
         operator = _controlled(operator, len(control))
         state_dims = (*control, *target)  # type: ignore[arg-type]
@@ -109,9 +109,9 @@ def apply_operator_dm(
 def apply_kraus_operator(
     kraus: Array,
     state: State,
-    target: Tuple[int, ...],
+    target: tuple[int, ...],
 ) -> State:
-    state_dims: Tuple[int, ...] = target
+    state_dims: tuple[int, ...] = target
     n_qubits = int(np.log2(kraus.size))
     kraus = kraus.reshape(tuple(2 for _ in np.arange(n_qubits)))
     op_dims = tuple(np.arange(kraus.ndim // 2, kraus.ndim, dtype=int))
@@ -131,8 +131,8 @@ def apply_kraus_operator(
 def apply_operator_with_noise(
     state: State,
     operator: Array,
-    target: Tuple[int, ...],
-    control: Tuple[int | None, ...],
+    target: tuple[int, ...],
+    control: tuple[int | None, ...],
     noise: NoiseProtocol,
     is_density: bool = False,
 ) -> State:
@@ -227,7 +227,7 @@ def apply_gate(
     Returns:
         State or density matrix after applying 'gate'.
     """
-    operator: Tuple[Array, ...]
+    operator: tuple[Array, ...]
     noise = list()
     if isinstance(gate, Primitive):
         operator_fn = getattr(gate, op_type)

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -141,7 +141,7 @@ def apply_operator_with_noise(
         if not is_density
         else apply_operator_dm(state, operator, target, control)
     )
-    if len(noise) == 0:
+    if noise is None:
         return state_gate
     else:
         kraus_ops = jnp.stack(tuple(reduce(add, tuple(n.kraus for n in noise))))
@@ -243,7 +243,8 @@ def apply_gate(
             operator, target, control = merge_operators(operator, target, control)
         noise = [g.noise for g in gate]
 
-    has_noise = len(reduce(add, noise)) > 0
+    # faster way to check has_noise
+    has_noise = noise != [None] * len(noise)
     if has_noise and not is_density:
         state = density_mat(state)
         is_density = True

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -61,15 +61,16 @@ def apply_operator(
     op_in_dims = tuple(np.arange(0, operator_reshaped.ndim // 2, dtype=int))
     # Apply operator
     state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
-    new_state_dims = tuple(i for i in range(len(state_dims)))
+   
     if not is_state_densitymat:
         # only return O ρ with correctly swaped axis for tensordot
+        new_state_dims = tuple(i for i in range(len(state_dims)))
         return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
     # Apply operator to density matrix: ρ' = O ρ O†
     state = _dagger(state)
     state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, op_in_dims))
     state = _dagger(state)
-    support_perm = target + tuple(set(new_state_dims) - set(target))
+    support_perm = target + tuple(set(tuple(range(state.ndim // 2))) - set(target))
     state = permute_basis(state, support_perm, True)
     return state
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -45,7 +45,7 @@ def apply_operator(
         operator: Array to contract over 'state'.
         target: Tuple of target qubits on which to apply the 'operator' to.
         control: Tuple of control qubits.
-        is_state_densitymat: Whether the state is provided as a density matrix.
+        is_density: Whether the state is provided as a density matrix.
 
     Returns:
         State after applying 'operator'.
@@ -78,7 +78,7 @@ def apply_operator_dm(
         operator: Array to contract over 'state'.
         target: Tuple of target qubits on which to apply the 'operator' to.
         control: Tuple of control qubits.
-        is_state_densitymat: Whether the state is provided as a density matrix.
+        is_density: Whether the state is provided as a density matrix.
 
     Returns:
         Density matrix after applying 'operator'.
@@ -134,11 +134,11 @@ def apply_operator_with_noise(
     target: Tuple[int, ...],
     control: Tuple[int | None, ...],
     noise: NoiseProtocol,
-    is_state_densitymat: bool = False,
+    is_density: bool = False,
 ) -> State:
     state_gate = (
         apply_operator(state, operator, target, control)
-        if not is_state_densitymat
+        if not is_density
         else apply_operator_dm(state, operator, target, control)
     )
     if len(noise) == 0:
@@ -212,7 +212,7 @@ def apply_gate(
     op_type: OperationType = OperationType.UNITARY,
     group_gates: bool = False,  # Defaulting to False since this can be performed once before circuit execution
     merge_ops: bool = True,
-    is_state_densitymat: bool = False,
+    is_density: bool = False,
 ) -> State:
     """Wrapper function for 'apply_operator' which applies a gate or a series of gates to a given state.
     Arguments:
@@ -222,7 +222,7 @@ def apply_gate(
         op_type: The type of operation to perform: Unitary, Dagger or Jacobian.
         group_gates: Group gates together which are acting on the same qubit.
         merge_ops: Attempt to merge operators acting on the same qubit.
-        is_state_densitymat: If True, state is provided as a density matrix.
+        is_density: If True, state is provided as a density matrix.
 
     Returns:
         State or density matrix after applying 'gate'.
@@ -244,13 +244,13 @@ def apply_gate(
         noise = [g.noise for g in gate]
 
     has_noise = len(reduce(add, noise)) > 0
-    if has_noise and not is_state_densitymat:
+    if has_noise and not is_density:
         state = density_mat(state)
-        is_state_densitymat = True
+        is_density = True
 
     output_state = reduce(
         lambda state, gate: apply_operator_with_noise(state, *gate),
-        zip(operator, target, control, noise, (is_state_densitymat,) * len(target)),
+        zip(operator, target, control, noise, (is_density,) * len(target)),
         state,
     )
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -58,7 +58,7 @@ def apply_operator(
     operator = operator.reshape(tuple(2 for _ in np.arange(2 * n_qubits_op)))
     op_out_dims = tuple(np.arange(operator.ndim // 2, operator.ndim, dtype=int))
     # Apply operator
-    new_state_dims = tuple(i for i in range(len(state_dims)))
+    new_state_dims = tuple(range(len(state_dims)))
     state = jnp.tensordot(a=operator, b=state, axes=(op_out_dims, state_dims))
     return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
 
@@ -91,7 +91,7 @@ def apply_operator_dm(
     operator = operator.reshape(tuple(2 for _ in np.arange(2 * n_qubits_op)))
     op_out_dims = tuple(np.arange(operator.ndim // 2, operator.ndim, dtype=int))
     op_in_dims = tuple(np.arange(0, operator.ndim // 2, dtype=int))
-    new_state_dims = tuple(i for i in range(len(state_dims)))
+    new_state_dims = tuple(range(len(state_dims)))
 
     # Apply operator to density matrix: ρ' = O ρ O†
     support_perm = state_dims + tuple(set(tuple(range(state.ndim // 2))) - set(state_dims))

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -48,20 +48,19 @@ def apply_operator(
         operator = _controlled(operator, len(control))
         state_dims = (*control, *target)  # type: ignore[arg-type]
     n_qubits_op = int(np.log2(operator.shape[1]))
-    operator = operator.reshape(tuple(2 for _ in np.arange(2 * n_qubits_op)))
-    op_out_dims = tuple(np.arange(operator.ndim // 2, operator.ndim, dtype=int))
-    op_in_dims = tuple(np.arange(0, operator.ndim // 2, dtype=int))
+    operator_reshaped = operator.reshape(tuple(2 for _ in np.arange(2 * n_qubits_op)))
+    op_out_dims = tuple(np.arange(operator_reshaped.ndim // 2, operator_reshaped.ndim, dtype=int))
+    op_in_dims = tuple(np.arange(0, operator_reshaped.ndim // 2, dtype=int))
     # Apply operator
-    state = jnp.tensordot(a=operator, b=state, axes=(op_out_dims, state_dims))
+    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
     new_state_dims = tuple(i for i in range(len(state_dims)))
     if not is_state_densitymat:
         return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
     # Apply operator to density matrix: ρ' = O ρ O†
     state = _dagger(state)
-    state = jnp.tensordot(a=operator, b=state, axes=(op_out_dims, op_in_dims))
-    state = jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
+    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, op_in_dims))
     state = _dagger(state)
-
+    state = jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
     return state
 
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -67,9 +67,7 @@ def apply_operator(
         return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
 
     # Apply operator to density matrix: ρ' = O ρ O†
-
     support_perm = target + tuple(set(tuple(range(state.ndim // 2))) - set(target))
-    # print("init 1", state.reshape((4, 4)).round(4))
     state = permute_basis(state, support_perm, False)
     state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, new_state_dims))
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -48,19 +48,20 @@ def apply_operator(
         operator = _controlled(operator, len(control))
         state_dims = (*control, *target)  # type: ignore[arg-type]
     n_qubits_op = int(np.log2(operator.shape[1]))
-    operator_reshaped = operator.reshape(tuple(2 for _ in np.arange(2 * n_qubits_op)))
-    op_dims = tuple(np.arange(operator_reshaped.ndim // 2, operator_reshaped.ndim, dtype=int))
+    operator = operator.reshape(tuple(2 for _ in np.arange(2 * n_qubits_op)))
+    op_out_dims = tuple(np.arange(operator.ndim // 2, operator.ndim, dtype=int))
+    op_in_dims = tuple(np.arange(0, operator.ndim // 2, dtype=int))
     # Apply operator
-
+    state = jnp.tensordot(a=operator, b=state, axes=(op_out_dims, state_dims))
     new_state_dims = tuple(i for i in range(len(state_dims)))
-    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_dims, state_dims))
     if not is_state_densitymat:
         return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
-    operator_dagger = _dagger(operator_reshaped)
-
     # Apply operator to density matrix: ρ' = O ρ O†
+    state = _dagger(state)
+    state = jnp.tensordot(a=operator, b=state, axes=(op_out_dims, op_in_dims))
+    state = jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
+    state = _dagger(state)
 
-    state = jnp.tensordot(a=operator_dagger, b=state, axes=(op_dims, state_dims))
     return state
 
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -61,17 +61,28 @@ def apply_operator(
     op_in_dims = tuple(np.arange(0, operator_reshaped.ndim // 2, dtype=int))
     # Apply operator
     state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
-   
+
     if not is_state_densitymat:
         # only return O ρ with correctly swaped axis for tensordot
+        state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
         new_state_dims = tuple(i for i in range(len(state_dims)))
         return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
-    # Apply operator to density matrix: ρ' = O ρ O†
-    state = _dagger(state)
-    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, op_in_dims))
-    state = _dagger(state)
     support_perm = target + tuple(set(tuple(range(state.ndim // 2))) - set(target))
+    print("init 1", state.reshape((4, 4)).round(4))
+    state = permute_basis(state, support_perm, False)
+    print("permute 1", state.reshape((4, 4)).round(4))
+    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
+    # Apply operator to density matrix: ρ' = O ρ O†
+    print("einsum 1", state.reshape((4, 4)).round(4))
+    state = _dagger(state)
+    print("dag 1", state.reshape((4, 4)).round(4))
+    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, op_in_dims))
+    print("einsum 2", state.reshape((4, 4)).round(4))
+    state = _dagger(state)
+    print("dag 2", state.reshape((4, 4)).round(4))
+
     state = permute_basis(state, support_perm, True)
+    print("permute", state.reshape((4, 4)).round(4))
     return state
 
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -60,29 +60,24 @@ def apply_operator(
     op_out_dims = tuple(np.arange(operator_reshaped.ndim // 2, operator_reshaped.ndim, dtype=int))
     op_in_dims = tuple(np.arange(0, operator_reshaped.ndim // 2, dtype=int))
     # Apply operator
-    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
-
+    new_state_dims = tuple(i for i in range(len(state_dims)))
     if not is_state_densitymat:
         # only return O ρ with correctly swaped axis for tensordot
         state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
-        new_state_dims = tuple(i for i in range(len(state_dims)))
         return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
-    support_perm = target + tuple(set(tuple(range(state.ndim // 2))) - set(target))
-    print("init 1", state.reshape((4, 4)).round(4))
-    state = permute_basis(state, support_perm, False)
-    print("permute 1", state.reshape((4, 4)).round(4))
-    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, state_dims))
+
     # Apply operator to density matrix: ρ' = O ρ O†
-    print("einsum 1", state.reshape((4, 4)).round(4))
+
+    support_perm = target + tuple(set(tuple(range(state.ndim // 2))) - set(target))
+    # print("init 1", state.reshape((4, 4)).round(4))
+    state = permute_basis(state, support_perm, False)
+    state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, new_state_dims))
+
     state = _dagger(state)
-    print("dag 1", state.reshape((4, 4)).round(4))
     state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, op_in_dims))
-    print("einsum 2", state.reshape((4, 4)).round(4))
     state = _dagger(state)
-    print("dag 2", state.reshape((4, 4)).round(4))
 
     state = permute_basis(state, support_perm, True)
-    print("permute", state.reshape((4, 4)).round(4))
     return state
 
 

--- a/horqrux/apply.py
+++ b/horqrux/apply.py
@@ -67,7 +67,7 @@ def apply_operator(
         return jnp.moveaxis(a=state, source=new_state_dims, destination=state_dims)
 
     # Apply operator to density matrix: ρ' = O ρ O†
-    support_perm = target + tuple(set(tuple(range(state.ndim // 2))) - set(target))
+    support_perm = state_dims + tuple(set(tuple(range(state.ndim // 2))) - set(state_dims))
     state = permute_basis(state, support_perm, False)
     state = jnp.tensordot(a=operator_reshaped, b=state, axes=(op_out_dims, new_state_dims))
 

--- a/horqrux/circuit.py
+++ b/horqrux/circuit.py
@@ -1,20 +1,16 @@
 from __future__ import annotations
 
-from collections import Counter
 from dataclasses import dataclass, field
 from typing import Any, Callable
 from uuid import uuid4
 
-import jax
-import jax.numpy as jnp
 from jax import Array
 from jax.tree_util import register_pytree_node_class
 
-from horqrux.adjoint import ad_expectation, adjoint_expectation
 from horqrux.apply import apply_gate
 from horqrux.parametric import RX, RY, Parametric
 from horqrux.primitive import NOT, Primitive
-from horqrux.utils import DiffMode, zero_state
+from horqrux.utils import zero_state
 
 
 @register_pytree_node_class
@@ -113,48 +109,3 @@ def hea(
             gates += ops
 
     return gates
-
-
-def expectation(
-    state: Array,
-    gates: list[Primitive],
-    observable: list[Primitive],
-    values: dict[str, float],
-    diff_mode: DiffMode | str = DiffMode.AD,
-) -> Array:
-    """
-    Run 'state' through a sequence of 'gates' given parameters 'values'
-    and compute the expectation given an observable.
-    """
-    if diff_mode == DiffMode.AD:
-        return ad_expectation(state, gates, observable, values)
-    else:
-        return adjoint_expectation(state, gates, observable, values)
-
-
-def sample(
-    state: Array,
-    gates: list[Primitive],
-    values: dict[str, float] = dict(),
-    n_shots: int = 1000,
-) -> Counter:
-    if n_shots < 1:
-        raise ValueError("You can only call sample with n_shots>0.")
-
-    wf = apply_gate(state, gates, values)
-    probs = jnp.abs(jnp.float_power(wf, 2.0)).ravel()
-    key = jax.random.PRNGKey(0)
-    n_qubits = len(state.shape)
-    # JAX handles pseudo random number generation by tracking an explicit state via a random key
-    # For more details, see https://jax.readthedocs.io/en/latest/random-numbers.html
-    samples = jax.vmap(
-        lambda subkey: jax.random.choice(key=subkey, a=jnp.arange(0, 2**n_qubits), p=probs)
-    )(jax.random.split(key, n_shots))
-
-    return Counter(
-        {
-            format(k, "0{}b".format(n_qubits)): count.item()
-            for k, count in enumerate(jnp.bincount(samples))
-            if count > 0
-        }
-    )

--- a/horqrux/noise.py
+++ b/horqrux/noise.py
@@ -20,7 +20,7 @@ from .utils_noise import (
 )
 
 
-class NoiseType(StrEnum):
+class DigitalNoiseType(StrEnum):
     BITFLIP = "BitFlip"
     PHASEFLIP = "PhaseFlip"
     DEPOLARIZING = "Depolarizing"
@@ -43,8 +43,8 @@ PROTOCOL_TO_KRAUS_FN: dict[str, Callable] = {
 
 @register_pytree_node_class
 @dataclass
-class NoiseInstance:
-    type: NoiseType
+class DigitalNoiseInstance:
+    type: DigitalNoiseType
     error_probability: tuple[float, ...] | float
 
     def __iter__(self) -> Iterable:
@@ -52,7 +52,7 @@ class NoiseInstance:
 
     def tree_flatten(
         self,
-    ) -> tuple[tuple, tuple[NoiseType, tuple[float, ...] | float]]:
+    ) -> tuple[tuple, tuple[DigitalNoiseType, tuple[float, ...] | float]]:
         children = ()
         aux_data = (self.type, self.error_probability)
         return (children, aux_data)
@@ -70,4 +70,4 @@ class NoiseInstance:
         return self.type + f"(p={self.error_probability})"
 
 
-NoiseProtocol = Union[tuple[NoiseInstance, ...], None]
+NoiseProtocol = Union[tuple[DigitalNoiseInstance, ...], None]

--- a/horqrux/noise.py
+++ b/horqrux/noise.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable, Tuple
+from typing import Any, Callable, Iterable
 
 from jax import Array
 from jax.tree_util import register_pytree_node_class
@@ -53,7 +53,7 @@ class NoiseInstance:
 
     def tree_flatten(
         self,
-    ) -> Tuple[Tuple, Tuple[NoiseType, ErrorProbabilities]]:
+    ) -> tuple[tuple, tuple[NoiseType, ErrorProbabilities]]:
         children = ()
         aux_data = (self.type, self.error_probability)
         return (children, aux_data)
@@ -71,4 +71,4 @@ class NoiseInstance:
         return self.type + f"(p={self.error_probability})"
 
 
-NoiseProtocol = Tuple[NoiseInstance, ...]
+NoiseProtocol = tuple[NoiseInstance, ...]

--- a/horqrux/noise.py
+++ b/horqrux/noise.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import Any, Callable, Iterable
+from typing import Any, Callable, Iterable, Union
 
 from jax import Array
 from jax.tree_util import register_pytree_node_class
@@ -70,4 +70,4 @@ class NoiseInstance:
         return self.type + f"(p={self.error_probability})"
 
 
-NoiseProtocol = tuple[NoiseInstance, ...] | None
+NoiseProtocol = Union[tuple[NoiseInstance, ...], None]

--- a/horqrux/noise.py
+++ b/horqrux/noise.py
@@ -7,7 +7,6 @@ from jax import Array
 from jax.tree_util import register_pytree_node_class
 
 from .utils import (
-    ErrorProbabilities,
     StrEnum,
 )
 from .utils_noise import (
@@ -46,14 +45,14 @@ PROTOCOL_TO_KRAUS_FN: dict[str, Callable] = {
 @dataclass
 class NoiseInstance:
     type: NoiseType
-    error_probability: ErrorProbabilities
+    error_probability: tuple[float, ...] | float
 
     def __iter__(self) -> Iterable:
         return iter((self.kraus, self.error_probability))
 
     def tree_flatten(
         self,
-    ) -> tuple[tuple, tuple[NoiseType, ErrorProbabilities]]:
+    ) -> tuple[tuple, tuple[NoiseType, tuple[float, ...] | float]]:
         children = ()
         aux_data = (self.type, self.error_probability)
         return (children, aux_data)
@@ -71,4 +70,4 @@ class NoiseInstance:
         return self.type + f"(p={self.error_probability})"
 
 
-NoiseProtocol = tuple[NoiseInstance, ...]
+NoiseProtocol = tuple[NoiseInstance, ...] | None

--- a/horqrux/parametric.py
+++ b/horqrux/parametric.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Tuple
+from typing import Any, Iterable
 
 import jax.numpy as jnp
 from jax import Array
@@ -47,7 +47,7 @@ class Parametric(Primitive):
 
     def tree_flatten(  # type: ignore[override]
         self,
-    ) -> Tuple[Tuple, Tuple[str, Tuple, Tuple, NoiseProtocol, str | float]]:
+    ) -> tuple[tuple, tuple[str, tuple, tuple, NoiseProtocol, str | float]]:
         children = ()
         aux_data = (
             self.generator_name,
@@ -90,7 +90,7 @@ def RX(
 
     Arguments:
         param: Parameter denoting the Rotational angle.
-        target: Tuple of target qubits denoted as ints.
+        target: tuple of target qubits denoted as ints.
         control: Optional tuple of control qubits denoted as ints.
         noise: The noise instance. Defaults to None.
 
@@ -110,7 +110,7 @@ def RY(
 
     Arguments:
         param: Parameter denoting the Rotational angle.
-        target: Tuple of target qubits denoted as ints.
+        target: tuple of target qubits denoted as ints.
         control: Optional tuple of control qubits denoted as ints.
         noise: The noise instance. Defaults to None.
 
@@ -130,7 +130,7 @@ def RZ(
 
     Arguments:
         param: Parameter denoting the Rotational angle.
-        target: Tuple of target qubits denoted as ints.
+        target: tuple of target qubits denoted as ints.
         control: Optional tuple of control qubits denoted as ints.
         noise: The noise instance. Defaults to None.
 
@@ -167,7 +167,7 @@ def PHASE(
 
     Arguments:
         param: Parameter denoting the Rotational angle.
-        target: Tuple of target qubits denoted as ints.
+        target: tuple of target qubits denoted as ints.
         control: Optional tuple of control qubits denoted as ints.
         noise: The noise instance. Defaults to None.
 

--- a/horqrux/parametric.py
+++ b/horqrux/parametric.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Iterable
 
 import jax.numpy as jnp
@@ -31,7 +31,7 @@ class Parametric(Primitive):
     generator_name: str
     target: QubitSupport
     control: QubitSupport
-    noise: NoiseProtocol = field(default_factory=tuple)
+    noise: NoiseProtocol = None
     param: str | float = ""
 
     def __post_init__(self) -> None:
@@ -84,7 +84,7 @@ def RX(
     param: float | str,
     target: TargetQubits,
     control: ControlQubits = (None,),
-    noise: NoiseProtocol = tuple(),
+    noise: NoiseProtocol = None,
 ) -> Parametric:
     """RX gate.
 
@@ -104,7 +104,7 @@ def RY(
     param: float | str,
     target: TargetQubits,
     control: ControlQubits = (None,),
-    noise: NoiseProtocol = tuple(),
+    noise: NoiseProtocol = None,
 ) -> Parametric:
     """RY gate.
 
@@ -124,7 +124,7 @@ def RZ(
     param: float | str,
     target: TargetQubits,
     control: ControlQubits = (None,),
-    noise: NoiseProtocol = tuple(),
+    noise: NoiseProtocol = None,
 ) -> Parametric:
     """RZ gate.
 
@@ -161,7 +161,7 @@ def PHASE(
     param: float,
     target: TargetQubits,
     control: ControlQubits = (None,),
-    noise: NoiseProtocol = tuple(),
+    noise: NoiseProtocol = None,
 ) -> Parametric:
     """Phase gate.
 

--- a/horqrux/primitive.py
+++ b/horqrux/primitive.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass, field
-from typing import Any, Iterable, Tuple, Union
+from typing import Any, Iterable, Union
 
 import numpy as np
 from jax import Array
@@ -32,8 +32,8 @@ class Primitive:
 
     @staticmethod
     def parse_idx(
-        idx: Tuple,
-    ) -> Tuple:
+        idx: tuple,
+    ) -> tuple:
         if isinstance(idx, (int, np.int64)):
             return ((idx,),)
         elif isinstance(idx, tuple):
@@ -51,7 +51,7 @@ class Primitive:
     def __iter__(self) -> Iterable:
         return iter((self.generator_name, self.target, self.control, self.noise))
 
-    def tree_flatten(self) -> Tuple[Tuple, Tuple[str, TargetQubits, ControlQubits, NoiseProtocol]]:
+    def tree_flatten(self) -> tuple[tuple, tuple[str, TargetQubits, ControlQubits, NoiseProtocol]]:
         children = ()
         aux_data = (self.generator_name, self.target[0], self.control[0], self.noise)
         return (children, aux_data)
@@ -93,7 +93,7 @@ def I(
     Example usage: I(1) represents the instruction to apply I to qubit 1.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints indicating the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.
 
@@ -113,7 +113,7 @@ def X(
     Example usage controlled: X(1, 0) represents the instruction to apply CX / CNOT to qubit 1 with controlled qubit 0.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints indicating the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.
 
@@ -136,7 +136,7 @@ def Y(
     Example usage controlled: Y(1, 0) represents the instruction to apply CY to qubit 1 with controlled qubit 0.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints indicating the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.
 
@@ -156,7 +156,7 @@ def Z(
     Example usage controlled: Z(1, 0) represents the instruction to apply CZ to qubit 1 with controlled qubit 0.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints indicating the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.
 
@@ -175,7 +175,7 @@ def H(
     Example usage: H(1) represents the instruction to apply Hadamard to qubit 1.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints indicating the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.
 
@@ -194,7 +194,7 @@ def S(
     Example usage: S(1) represents the instruction to apply S to qubit 1.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints indicating the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.
 
@@ -213,7 +213,7 @@ def T(
     Example usage: T(1) represents the instruction to apply Hadamard to qubit 1.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints indicating the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.
 
@@ -236,7 +236,7 @@ def SWAP(
     Example usage controlled: SWAP(((0, 1), ), ((2, ))) swaps qubits 0 and 1 with controlled bit 2.
 
     Args:
-        target: Tuple of ints describing the qubits to apply to.
+        target: tuple of ints describing the qubits to apply to.
         control: Optional tuple of ints or None describing
         the control qubits. Defaults to (None,).
         noise: The noise instance. Defaults to None.

--- a/horqrux/primitive.py
+++ b/horqrux/primitive.py
@@ -1,6 +1,6 @@
 from __future__ import annotations
 
-from dataclasses import dataclass, field
+from dataclasses import dataclass
 from typing import Any, Iterable, Union
 
 import numpy as np
@@ -28,7 +28,7 @@ class Primitive:
     generator_name: str
     target: QubitSupport
     control: QubitSupport
-    noise: NoiseProtocol = field(default_factory=tuple)
+    noise: NoiseProtocol | None = None
 
     @staticmethod
     def parse_idx(
@@ -85,7 +85,7 @@ GateSequence = Union[Primitive, Iterable[Primitive]]
 
 
 def I(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """Identity / I gate. This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
@@ -104,7 +104,7 @@ def I(
 
 
 def X(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """X gate. This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
@@ -127,7 +127,7 @@ NOT = X
 
 
 def Y(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """Y gate. This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
@@ -147,7 +147,7 @@ def Y(
 
 
 def Z(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """Z gate. This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
@@ -167,7 +167,7 @@ def Z(
 
 
 def H(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """H/ Hadamard gate. This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
@@ -186,7 +186,7 @@ def H(
 
 
 def S(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """S gate or constant phase gate. This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
@@ -205,7 +205,7 @@ def S(
 
 
 def T(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """T gate. This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
@@ -227,7 +227,7 @@ def T(
 
 
 def SWAP(
-    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = tuple()
+    target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """SWAP gate. By providing a control, it turns into a controlled gate (Fredkin gate),
        use None for no control qubits.

--- a/horqrux/primitive.py
+++ b/horqrux/primitive.py
@@ -28,7 +28,7 @@ class Primitive:
     generator_name: str
     target: QubitSupport
     control: QubitSupport
-    noise: NoiseProtocol | None = None
+    noise: NoiseProtocol = None
 
     @staticmethod
     def parse_idx(

--- a/horqrux/primitive.py
+++ b/horqrux/primitive.py
@@ -107,7 +107,7 @@ def X(
     target: TargetQubits, control: ControlQubits = (None,), noise: NoiseProtocol = None
 ) -> Primitive:
     """The definition for the X gate.
-    
+
     This function returns an instance of 'Primitive' and does *not* apply the gate.
     By providing tuple of ints to 'control', it turns into a controlled gate.
 

--- a/horqrux/shots.py
+++ b/horqrux/shots.py
@@ -49,7 +49,9 @@ def eigen_probabilities(state: Any, eigvecs: Array) -> Array:
     Returns:
         Array: The probabilities.
     """
-    raise NotImplementedError(f"prod_eigenvectors_state is not implemented for the state type {type(state)}.")
+    raise NotImplementedError(
+        f"prod_eigenvectors_state is not implemented for the state type {type(state)}."
+    )
 
 
 @eigen_probabilities.register

--- a/horqrux/shots.py
+++ b/horqrux/shots.py
@@ -13,7 +13,7 @@ from horqrux.primitive import GateSequence, Primitive
 from horqrux.utils import DensityMatrix, State, none_like
 
 
-def observable_to_matrix(
+def to_matrix(
     observable: Primitive,
     n_qubits: int,
     values: dict[str, float],
@@ -50,7 +50,7 @@ def eigen_probabilities(state: Any, eigvecs: Array) -> Array:
         Array: The probabilities.
     """
     raise NotImplementedError(
-        f"prod_eigenvectors_state is not implemented for the state type {type(state)}."
+        f"eigen_probabilities is not implemented for the state type {type(state)}."
     )
 
 
@@ -88,7 +88,7 @@ def _(state: DensityMatrix, eigvecs: Array) -> Array:
     return mat_prob.diagonal().real
 
 
-def eigenval_decomposition_sampling(
+def eigen_sample(
     state: State,
     observables: list[Primitive],
     values: dict[str, float],
@@ -96,7 +96,7 @@ def eigenval_decomposition_sampling(
     n_shots: int,
     key: Any = jax.random.PRNGKey(0),
 ) -> Array:
-    mat_obs = [observable_to_matrix(observable, n_qubits, values) for observable in observables]
+    mat_obs = [to_matrix(observable, n_qubits, values) for observable in observables]
     eigs = [jnp.linalg.eigh(mat) for mat in mat_obs]
     eigvecs, eigvals = align_eigenvectors(eigs)
     probs = eigen_probabilities(state, eigvecs)
@@ -124,7 +124,7 @@ def finite_shots_fwd(
     else:
         output_gates = apply_gate(state, gates, values)
         n_qubits = len(state.shape)
-    return eigenval_decomposition_sampling(
+    return eigen_sample(
         output_gates, observables, values, n_qubits, n_shots, key
     )
 

--- a/horqrux/shots.py
+++ b/horqrux/shots.py
@@ -124,9 +124,7 @@ def finite_shots_fwd(
     else:
         output_gates = apply_gate(state, gates, values)
         n_qubits = len(state.shape)
-    return eigen_sample(
-        output_gates, observables, values, n_qubits, n_shots, key
-    )
+    return eigen_sample(output_gates, observables, values, n_qubits, n_shots, key)
 
 
 def align_eigenvectors(eigs: list[tuple[Array, Array]]) -> tuple[Array, Array]:

--- a/horqrux/shots.py
+++ b/horqrux/shots.py
@@ -43,7 +43,7 @@ def probs_from_eigenvectors_state(state: Any, eigvecs: Array) -> Array:
        of an observable.
 
     Args:
-        state (Array): Input array.
+        state (Any): Input.
         eigvecs (Array): Eigenvectors of the observables.
 
     Returns:

--- a/horqrux/shots.py
+++ b/horqrux/shots.py
@@ -10,7 +10,7 @@ from jax.experimental import checkify
 
 from horqrux.apply import apply_gate
 from horqrux.primitive import GateSequence, Primitive
-from horqrux.utils import DensityMatrix, none_like
+from horqrux.utils import DensityMatrix, State, none_like
 
 
 def observable_to_matrix(
@@ -38,7 +38,7 @@ def observable_to_matrix(
 
 
 @singledispatch
-def probs_from_eigenvectors_state(state: Array, eigvecs: Array) -> Array:
+def probs_from_eigenvectors_state(state: Any, eigvecs: Array) -> Array:
     """Obtain the probabilities using an input state and the eigenvectors decomposition
        of an observable.
 
@@ -76,7 +76,7 @@ def _(state: DensityMatrix, eigvecs: Array) -> Array:
         of an observable.
 
     Args:
-        state (DensityMatrix): Input array.
+        state (DensityMatrix): Input density matrix.
         eigvecs (Array): Eigenvectors of the observables.
 
     Returns:
@@ -87,7 +87,7 @@ def _(state: DensityMatrix, eigvecs: Array) -> Array:
 
 
 def eigenval_decomposition_sampling(
-    state: Array | DensityMatrix,
+    state: State,
     observables: list[Primitive],
     values: dict[str, float],
     n_qubits: int,
@@ -103,7 +103,7 @@ def eigenval_decomposition_sampling(
 
 @partial(jax.custom_jvp, nondiff_argnums=(0, 1, 2, 4, 5))
 def finite_shots_fwd(
-    state: Array | DensityMatrix,
+    state: State,
     gates: GateSequence,
     observables: list[Primitive],
     values: dict[str, float],

--- a/horqrux/shots.py
+++ b/horqrux/shots.py
@@ -63,7 +63,9 @@ def finite_shots_fwd(
     """
     if isinstance(state, DensityMatrix):
         output_gates = apply_gate(state, gates, values).array
-        n_qubits = len(output_gates.array.shape) // 2
+        n_qubits = len(output_gates.shape) // 2
+        d = 2**n_qubits
+        output_gates = output_gates.reshape((d, d))
     else:
         output_gates = apply_gate(state, gates, values)
         n_qubits = len(state.shape)

--- a/horqrux/shots.py
+++ b/horqrux/shots.py
@@ -38,7 +38,7 @@ def observable_to_matrix(
 
 
 @singledispatch
-def probs_from_eigenvectors_state(state: Any, eigvecs: Array) -> Array:
+def eigen_probabilities(state: Any, eigvecs: Array) -> Array:
     """Obtain the probabilities using an input state and the eigenvectors decomposition
        of an observable.
 
@@ -52,7 +52,7 @@ def probs_from_eigenvectors_state(state: Any, eigvecs: Array) -> Array:
     raise NotImplementedError("prod_eigenvectors_state is not implemented")
 
 
-@probs_from_eigenvectors_state.register
+@eigen_probabilities.register
 def _(state: Array, eigvecs: Array) -> Array:
     """Obtain the probabilities using an input quantum state vector
         and the eigenvectors decomposition
@@ -69,7 +69,7 @@ def _(state: Array, eigvecs: Array) -> Array:
     return jnp.abs(inner_prod) ** 2
 
 
-@probs_from_eigenvectors_state.register
+@eigen_probabilities.register
 def _(state: DensityMatrix, eigvecs: Array) -> Array:
     """Obtain the probabilities using an input quantum density matrix
         and the eigenvectors decomposition
@@ -97,7 +97,7 @@ def eigenval_decomposition_sampling(
     mat_obs = [observable_to_matrix(observable, n_qubits, values) for observable in observables]
     eigs = [jnp.linalg.eigh(mat) for mat in mat_obs]
     eigvecs, eigvals = align_eigenvectors(eigs)
-    probs = probs_from_eigenvectors_state(state, eigvecs)
+    probs = eigen_probabilities(state, eigvecs)
     return jax.random.choice(key=key, a=eigvals, p=probs, shape=(n_shots,)).mean(axis=0)
 
 

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -44,14 +44,14 @@ class DensityMatrix:
 State = Union[ArrayLike, DensityMatrix]
 
 
-def density_mat(state: State) -> DensityMatrix:
+def density_mat(state: ArrayLike) -> DensityMatrix:
     """Convert state to density matrix
 
     Args:
-        state (State): Input state.
+        state (ArrayLike): Input state.
 
     Returns:
-        State: Density matrix representation.
+        DensityMatrix: Density matrix representation.
     """
     # Expand dimensions to enable broadcasting
     if isinstance(state, DensityMatrix):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -18,7 +18,7 @@ State = ArrayLike
 QubitSupport = Tuple[Any, ...]
 ControlQubits = Tuple[Union[None, Tuple[int, ...]], ...]
 TargetQubits = Tuple[Tuple[int, ...], ...]
-ErrorProbabilities = Tuple[float, ...] | float
+ErrorProbabilities = Union[Tuple[float, ...], float]
 
 ATOL = 1e-014
 

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -23,13 +23,18 @@ ErrorProbabilities = Union[Tuple[float, ...], float]
 ATOL = 1e-014
 
 
-class DensityMatrix:
-    def __init__(self, state: ArrayLike) -> None:
-        n_qubits = len(state.shape)
-        state = state.reshape(2**n_qubits)
-        self.dm = jnp.einsum("i,j->ij", state, state.conj()).reshape(
-            tuple(2 for _ in range(2 * n_qubits))
-        )
+def density_mat(state: Array) -> Array:
+    """Convert state to density matrix
+
+    Args:
+        state (State): Input state.
+
+    Returns:
+        State: Density matrix representation.
+    """
+    n_qubits = len(state.shape)
+    state = state.reshape(2**n_qubits)
+    return jnp.einsum("i,j->ij", state, state.conj()).reshape(tuple(2 for _ in range(2 * n_qubits)))
 
 
 class StrEnum(str, Enum):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -18,8 +18,6 @@ State = ArrayLike
 QubitSupport = tuple[Any, ...]
 ControlQubits = tuple[Union[None, tuple[int, ...]], ...]
 TargetQubits = tuple[tuple[int, ...], ...]
-ErrorProbabilities = Union[tuple[float, ...], float]
-
 ATOL = 1e-014
 
 

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -18,7 +18,6 @@ from ._misc import default_complex_dtype
 
 default_dtype = default_complex_dtype()
 
-State = ArrayLike
 QubitSupport = tuple[Any, ...]
 ControlQubits = tuple[Union[None, tuple[int, ...]], ...]
 TargetQubits = tuple[tuple[int, ...], ...]
@@ -42,7 +41,10 @@ class DensityMatrix:
         return cls(*children, *aux_data)
 
 
-def density_mat(state: Array | DensityMatrix) -> DensityMatrix:
+State = Union[ArrayLike, DensityMatrix]
+
+
+def density_mat(state: State) -> DensityMatrix:
     """Convert state to density matrix
 
     Args:

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -268,7 +268,7 @@ def sample_from_probs(probs: Array, n_qubits: int, n_shots: int) -> Counter:
 
     return Counter(
         {
-            format(k, "0{}b".format(n_qubits)): count.item()
+            format(k, f"0{n_qubits}b"): count.item()
             for k, count in enumerate(jnp.bincount(samples))
             if count > 0
         }
@@ -276,7 +276,7 @@ def sample_from_probs(probs: Array, n_qubits: int, n_shots: int) -> Counter:
 
 
 @singledispatch
-def get_probas(state: Array) -> Array:
+def probabilities(state: Array) -> Array:
     """Extract probabilities from state or density matrix.
 
     Args:
@@ -288,14 +288,14 @@ def get_probas(state: Array) -> Array:
     Returns:
         Array: Vector of probabilities.
     """
-    raise NotImplementedError("get_probas is not implemented")
+    raise NotImplementedError("probabilities is not implemented")
 
 
-@get_probas.register
+@probabilities.register
 def _(state: Array) -> Array:
     return jnp.abs(jnp.float_power(state, 2.0)).ravel()
 
 
-@get_probas.register
+@probabilities.register
 def _(state: DensityMatrix) -> Array:
     return jnp.diagonal(state.array).real

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -231,7 +231,7 @@ def uniform_state(
     return state.reshape([2] * n_qubits)
 
 
-def is_controlled(qubit_support: tuple[int | None, ...] | int | None) -> bool:
+def is_controlled(qubit_support: tuple[Union[int, None], ...] | Union[int, None]) -> bool:
     if isinstance(qubit_support, int):
         return True
     elif isinstance(qubit_support, tuple):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -32,7 +32,7 @@ class DensityMatrix:
 
     def tree_flatten(self) -> tuple[tuple, tuple[Array]]:
         children = ()
-        aux_data = self.array
+        aux_data = (self.array,)
         return (children, aux_data)
 
     @classmethod

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -38,6 +38,30 @@ def density_mat(state: Array) -> Array:
     return ket * bra
 
 
+def permute_basis(operator: Array, qubit_support: tuple, inv: bool = False) -> Array:
+    """Takes an operator tensor and permutes the rows and
+    columns according to the order of the qubit support.
+
+    Args:
+        operator (Tensor): Operator to permute over.
+        qubit_support (tuple): Qubit support.
+        inv (bool): Applies the inverse permutation instead.
+
+    Returns:
+        Tensor: Permuted operator.
+    """
+    ordered_support = np.argsort(qubit_support)
+    ranked_support = np.argsort(ordered_support)
+    n_qubits = len(qubit_support)
+    if all(a == b for a, b in zip(ranked_support, list(range(n_qubits)))):
+        return operator
+
+    perm = tuple(ranked_support) + tuple(ranked_support + n_qubits)
+    if inv:
+        perm = np.argsort(perm)
+    return jnp.transpose(operator, perm)
+
+
 class StrEnum(str, Enum):
     def __str__(self) -> str:
         """Used when dumping enum fields in a schema."""

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -32,9 +32,10 @@ def density_mat(state: Array) -> Array:
     Returns:
         State: Density matrix representation.
     """
-    n_qubits = len(state.shape)
-    state = state.reshape(2**n_qubits)
-    return jnp.einsum("i,j->ij", state, state.conj()).reshape(tuple(2 for _ in range(2 * n_qubits)))
+    # Expand dimensions to enable broadcasting
+    ket = jnp.expand_dims(state, axis=tuple(range(state.ndim, 2 * state.ndim)))
+    bra = jnp.conj(jnp.expand_dims(state, axis=tuple(range(state.ndim))))
+    return ket * bra
 
 
 class StrEnum(str, Enum):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -53,13 +53,13 @@ def permute_basis(operator: Array, qubit_support: tuple, inv: bool = False) -> A
     ordered_support = np.argsort(qubit_support)
     ranked_support = np.argsort(ordered_support)
     n_qubits = len(qubit_support)
-    if all(a == b for a, b in zip(ranked_support, list(range(n_qubits)))):
+    if all(a == b for a, b in zip(ranked_support, tuple(range(n_qubits)))):
         return operator
 
     perm = tuple(ranked_support) + tuple(ranked_support + n_qubits)
     if inv:
         perm = np.argsort(perm)
-    return jnp.transpose(operator, perm)
+    return jnp.moveaxis(operator, source=tuple(range(operator.ndim)), destination=perm)
 
 
 class StrEnum(str, Enum):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -59,7 +59,8 @@ def permute_basis(operator: Array, qubit_support: tuple, inv: bool = False) -> A
     perm = tuple(ranked_support) + tuple(ranked_support + n_qubits)
     if inv:
         perm = np.argsort(perm)
-    return jnp.moveaxis(operator, source=tuple(range(operator.ndim)), destination=perm)
+    return jax.lax.transpose(operator, perm)
+    # return jnp.moveaxis(operator, source=tuple(range(operator.ndim)), destination=perm)
 
 
 class StrEnum(str, Enum):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -73,7 +73,18 @@ class ForwardMode(StrEnum):
 
 
 def _dagger(operator: Array) -> Array:
-    return jnp.conjugate(operator.T)
+    # If the operator is a tensor with repeated 2D axes
+    if operator.ndim > 2:
+        # Conjugate and swap the last two axes
+        conjugated = operator.conj()
+
+        # Create the transpose axes: swap pairs of indices
+        half = operator.ndim // 2
+        axes = tuple(range(half, operator.ndim)) + tuple(range(half))
+        return jnp.transpose(conjugated, axes)
+    else:
+        # For standard matrices, use conjugate transpose
+        return jnp.conjugate(operator.T)
 
 
 def _unitary(generator: Array, theta: float) -> Array:

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -276,7 +276,7 @@ def sample_from_probs(probs: Array, n_qubits: int, n_shots: int) -> Counter:
 
 
 @singledispatch
-def probabilities(state: Array) -> Array:
+def probabilities(state: Any) -> Array:
     """Extract probabilities from state or density matrix.
 
     Args:
@@ -299,3 +299,26 @@ def _(state: Array) -> Array:
 @probabilities.register
 def _(state: DensityMatrix) -> Array:
     return jnp.diagonal(state.array).real
+
+
+@singledispatch
+def num_qubits(state: Any) -> int:
+    """Returns the number of qubits of a state.
+
+    Args:
+        state (Any): state.
+
+    Returns:
+        int: Number of qubits.
+    """
+    raise NotImplementedError(f"num_qubits is not implemented for the state type {type(state)}.")
+
+
+@num_qubits.register
+def _(state: Array) -> int:
+    return len(state.shape)
+
+
+@num_qubits.register
+def _(state: DensityMatrix) -> int:
+    return len(state.array.shape) // 2

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -231,7 +231,7 @@ def uniform_state(
     return state.reshape([2] * n_qubits)
 
 
-def is_controlled(qubit_support: tuple[Union[int, None], ...] | Union[int, None]) -> bool:
+def is_controlled(qubit_support: Union[tuple[Union[int, None], ...], int, None]) -> bool:
     if isinstance(qubit_support, int):
         return True
     elif isinstance(qubit_support, tuple):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -60,7 +60,6 @@ def permute_basis(operator: Array, qubit_support: tuple, inv: bool = False) -> A
     if inv:
         perm = np.argsort(perm)
     return jax.lax.transpose(operator, perm)
-    # return jnp.moveaxis(operator, source=tuple(range(operator.ndim)), destination=perm)
 
 
 class StrEnum(str, Enum):

--- a/horqrux/utils.py
+++ b/horqrux/utils.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from enum import Enum
-from typing import Any, Iterable, Tuple, Union
+from typing import Any, Iterable, Union
 
 import jax
 import jax.numpy as jnp
@@ -15,10 +15,10 @@ from ._misc import default_complex_dtype
 default_dtype = default_complex_dtype()
 
 State = ArrayLike
-QubitSupport = Tuple[Any, ...]
-ControlQubits = Tuple[Union[None, Tuple[int, ...]], ...]
-TargetQubits = Tuple[Tuple[int, ...], ...]
-ErrorProbabilities = Union[Tuple[float, ...], float]
+QubitSupport = tuple[Any, ...]
+ControlQubits = tuple[Union[None, tuple[int, ...]], ...]
+TargetQubits = tuple[tuple[int, ...], ...]
+ErrorProbabilities = Union[tuple[float, ...], float]
 
 ATOL = 1e-014
 
@@ -153,14 +153,14 @@ def zero_state(n_qubits: int) -> Array:
     return product_state("0" * n_qubits)
 
 
-def none_like(x: Iterable) -> Tuple[None, ...]:
+def none_like(x: Iterable) -> tuple[None, ...]:
     """Generates a tuple of Nones with equal length to x. Useful for gates with multiple targets but no control.
 
     Args:
         x (Iterable): Iterable to be mimicked.
 
     Returns:
-        Tuple[None, ...]: Tuple of Nones of length x.
+        tuple[None, ...]: tuple of Nones of length x.
     """
     return tuple(map(lambda _: None, x))
 
@@ -208,7 +208,7 @@ def uniform_state(
     return state.reshape([2] * n_qubits)
 
 
-def is_controlled(qubit_support: Tuple[int | None, ...] | int | None) -> bool:
+def is_controlled(qubit_support: tuple[int | None, ...] | int | None) -> bool:
     if isinstance(qubit_support, int):
         return True
     elif isinstance(qubit_support, tuple):

--- a/horqrux/utils_noise.py
+++ b/horqrux/utils_noise.py
@@ -104,7 +104,7 @@ def PauliChannel(error_probability: tuple[float, ...]) -> tuple[Array, ...]:
             + pz Z \\rho Z^{\\dagger}
 
     Args:
-        error_probability (ErrorProbabilities): tuple containing probabilities
+        error_probability (tuple[float, ...] | float): tuple containing probabilities
             of X, Y, and Z errors.
 
     Raises:
@@ -224,7 +224,7 @@ def GeneralizedAmplitudeDamping(error_probability: tuple[float, ...]) -> tuple[A
         K3 = sqrt(1-p) * [[0, 0], [sqrt(rate), 0]]
 
     Args:
-        error_probability (ErrorProbabilities): The first float must be the probability
+        error_probability (tuple[float, ...] | float): The first float must be the probability
             of amplitude damping error, and the second float is the damping rate, indicating
             the probability of generalized amplitude damping.
 

--- a/horqrux/utils_noise.py
+++ b/horqrux/utils_noise.py
@@ -104,7 +104,7 @@ def PauliChannel(error_probability: tuple[float, ...]) -> tuple[Array, ...]:
             + pz Z \\rho Z^{\\dagger}
 
     Args:
-        error_probability (ErrorProbabilities): Tuple containing probabilities
+        error_probability (ErrorProbabilities): tuple containing probabilities
             of X, Y, and Z errors.
 
     Raises:

--- a/horqrux/utils_noise.py
+++ b/horqrux/utils_noise.py
@@ -24,7 +24,7 @@ def BitFlip(error_probability: float) -> tuple[Array, ...]:
     Returns:
         tuple[Array, ...]: Kraus operators for this protocol.
     """
-    if error_probability > 1.0 or error_probability < 0.0:
+    if (error_probability > 1.0) or (error_probability < 0.0):
         raise ValueError("The error_probability value is not a correct probability")
     K0: Array = jnp.sqrt(1.0 - error_probability) * OPERATIONS_DICT["I"]
     K1: Array = jnp.sqrt(error_probability) * OPERATIONS_DICT["X"]
@@ -51,7 +51,7 @@ def PhaseFlip(error_probability: float) -> tuple[Array, ...]:
         tuple[Array, ...]: Kraus operators for this protocol.
     """
 
-    if error_probability > 1.0 or error_probability < 0.0:
+    if (error_probability > 1.0) or (error_probability < 0.0):
         raise ValueError("The error_probability value is not a correct probability")
     K0: Array = jnp.sqrt(1.0 - error_probability) * OPERATIONS_DICT["I"]
     K1: Array = jnp.sqrt(error_probability) * OPERATIONS_DICT["Z"]
@@ -81,7 +81,7 @@ def Depolarizing(error_probability: float) -> tuple[Array, ...]:
         tuple[Array, ...]: Kraus operators for this protocol.
     """
 
-    if error_probability > 1.0 or error_probability < 0.0:
+    if (error_probability > 1.0) or (error_probability < 0.0):
         raise ValueError("The error_probability value is not a correct probability")
     K0: Array = jnp.sqrt(1.0 - error_probability) * OPERATIONS_DICT["I"]
     K1: Array = jnp.sqrt(error_probability / 3.0) * OPERATIONS_DICT["X"]
@@ -118,7 +118,7 @@ def PauliChannel(error_probability: tuple[float, ...]) -> tuple[Array, ...]:
     if sum_prob > 1.0:
         raise ValueError("The sum of probabilities can't be greater than 1.0")
     for probability in error_probability:
-        if probability > 1.0 or probability < 0.0:
+        if (probability > 1.0) or (probability < 0.0):
             raise ValueError("The probability values are not correct probabilities")
     px, py, pz = (
         error_probability[0],
@@ -147,8 +147,8 @@ def AmplitudeDamping(error_probability: float) -> tuple[Array, ...]:
 
     .. code-block:: python
 
-        K0 = [[1, 0], [0, sqrt(1 - rate)]]
-        K1 = [[0, sqrt(rate)], [0, 0]]
+        K0 = [[1, 0], [0, sqrt(1 - error_probability)]]
+        K1 = [[0, sqrt(error_probability)], [0, 0]]
 
     Args:
         error_probability (float): The damping rate, indicating the probability of amplitude loss.
@@ -160,11 +160,10 @@ def AmplitudeDamping(error_probability: float) -> tuple[Array, ...]:
         tuple[Array, ...]: Kraus operators for this protocol.
     """
 
-    rate = error_probability
-    if rate > 1.0 or rate < 0.0:
+    if (error_probability > 1.0) or (error_probability < 0.0):
         raise ValueError("The damping rate is not a correct probability")
-    K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - rate)]], dtype=jnp.complex128)
-    K1: Array = jnp.array([[0, jnp.sqrt(rate)], [0, 0]], dtype=jnp.complex128)
+    K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - error_probability)]], dtype=jnp.complex128)
+    K1: Array = jnp.array([[0, jnp.sqrt(error_probability)], [0, 0]], dtype=jnp.complex128)
     kraus: tuple[Array, ...] = (K0, K1)
     return kraus
 
@@ -182,8 +181,8 @@ def PhaseDamping(error_probability: float) -> tuple[Array, ...]:
 
     .. code-block:: python
 
-        K0 = [[1, 0], [0, sqrt(1 - rate)]]
-        K1 = [[0, 0], [0, sqrt(rate)]]
+        K0 = [[1, 0], [0, sqrt(1 - error_probability)]]
+        K1 = [[0, 0], [0, sqrt(error_probability)]]
 
     Args:
         error_probability (float): The damping rate, indicating the probability of phase damping.
@@ -195,11 +194,10 @@ def PhaseDamping(error_probability: float) -> tuple[Array, ...]:
         tuple[Array, ...]: Kraus operators for this protocol.
     """
 
-    rate = error_probability
-    if rate > 1.0 or rate < 0.0:
+    if (error_probability > 1.0) or (error_probability < 0.0):
         raise ValueError("The damping rate is not a correct probability")
-    K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - rate)]], dtype=jnp.complex128)
-    K1: Array = jnp.array([[0, 0], [0, jnp.sqrt(rate)]], dtype=jnp.complex128)
+    K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - error_probability)]], dtype=jnp.complex128)
+    K1: Array = jnp.array([[0, 0], [0, jnp.sqrt(error_probability)]], dtype=jnp.complex128)
     kraus: tuple[Array, ...] = (K0, K1)
     return kraus
 
@@ -237,9 +235,9 @@ def GeneralizedAmplitudeDamping(error_probability: tuple[float, ...]) -> tuple[A
 
     probability = error_probability[0]
     rate = error_probability[1]
-    if probability > 1.0 or probability < 0.0:
+    if (probability > 1.0) or (probability < 0.0):
         raise ValueError("The probability value is not a correct probability")
-    if rate > 1.0 or rate < 0.0:
+    if (rate > 1.0) or (rate < 0.0):
         raise ValueError("The damping rate is not a correct probability")
 
     K0: Array = jnp.sqrt(probability) * jnp.array(

--- a/horqrux/utils_noise.py
+++ b/horqrux/utils_noise.py
@@ -25,7 +25,7 @@ def BitFlip(error_probability: float) -> tuple[Array, ...]:
         tuple[Array, ...]: Kraus operators for this protocol.
     """
     if (error_probability > 1.0) or (error_probability < 0.0):
-        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
+        raise ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.sqrt(1.0 - error_probability) * OPERATIONS_DICT["I"]
     K1: Array = jnp.sqrt(error_probability) * OPERATIONS_DICT["X"]
     kraus: tuple[Array, ...] = (K0, K1)
@@ -82,7 +82,7 @@ def Depolarizing(error_probability: float) -> tuple[Array, ...]:
     """
 
     if (error_probability > 1.0) or (error_probability < 0.0):
-        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
+        raise ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.sqrt(1.0 - error_probability) * OPERATIONS_DICT["I"]
     K1: Array = jnp.sqrt(error_probability / 3.0) * OPERATIONS_DICT["X"]
     K2: Array = jnp.sqrt(error_probability / 3.0) * OPERATIONS_DICT["Y"]
@@ -117,11 +117,8 @@ def PauliChannel(error_probability: tuple[float, ...]) -> tuple[Array, ...]:
     sum_prob = sum(error_probability)
     if sum_prob > 1.0:
         raise ValueError("The sum of probabilities can't be greater than 1.0")
-    for probability in error_probability:
-        if (probability > 1.0) or (probability < 0.0):
-            raise ValueError(
-                f"The 'error_probability' values are incorrect. Change value {probability}."
-            )
+    if any([probability > 1.0 or probability < 0.0 for probability in error_probability]):
+        raise ValueError(f"The 'error_probability' values are incorrect. Got {error_probability}.")
     px, py, pz = (
         error_probability[0],
         error_probability[1],
@@ -163,7 +160,7 @@ def AmplitudeDamping(error_probability: float) -> tuple[Array, ...]:
     """
 
     if (error_probability > 1.0) or (error_probability < 0.0):
-        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
+        raise ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - error_probability)]], dtype=jnp.complex128)
     K1: Array = jnp.array([[0, jnp.sqrt(error_probability)], [0, 0]], dtype=jnp.complex128)
     kraus: tuple[Array, ...] = (K0, K1)
@@ -197,7 +194,7 @@ def PhaseDamping(error_probability: float) -> tuple[Array, ...]:
     """
 
     if (error_probability > 1.0) or (error_probability < 0.0):
-        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
+        raise ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - error_probability)]], dtype=jnp.complex128)
     K1: Array = jnp.array([[0, 0], [0, jnp.sqrt(error_probability)]], dtype=jnp.complex128)
     kraus: tuple[Array, ...] = (K0, K1)

--- a/horqrux/utils_noise.py
+++ b/horqrux/utils_noise.py
@@ -25,7 +25,7 @@ def BitFlip(error_probability: float) -> tuple[Array, ...]:
         tuple[Array, ...]: Kraus operators for this protocol.
     """
     if (error_probability > 1.0) or (error_probability < 0.0):
-        raise ValueError("The error_probability value is not a correct probability")
+        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.sqrt(1.0 - error_probability) * OPERATIONS_DICT["I"]
     K1: Array = jnp.sqrt(error_probability) * OPERATIONS_DICT["X"]
     kraus: tuple[Array, ...] = (K0, K1)
@@ -82,7 +82,7 @@ def Depolarizing(error_probability: float) -> tuple[Array, ...]:
     """
 
     if (error_probability > 1.0) or (error_probability < 0.0):
-        raise ValueError("The error_probability value is not a correct probability")
+        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.sqrt(1.0 - error_probability) * OPERATIONS_DICT["I"]
     K1: Array = jnp.sqrt(error_probability / 3.0) * OPERATIONS_DICT["X"]
     K2: Array = jnp.sqrt(error_probability / 3.0) * OPERATIONS_DICT["Y"]
@@ -119,7 +119,9 @@ def PauliChannel(error_probability: tuple[float, ...]) -> tuple[Array, ...]:
         raise ValueError("The sum of probabilities can't be greater than 1.0")
     for probability in error_probability:
         if (probability > 1.0) or (probability < 0.0):
-            raise ValueError(f"The error probability values are incorrect. Got {probability}.")
+            raise ValueError(
+                f"The 'error_probability' values are incorrect. Change value {probability}."
+            )
     px, py, pz = (
         error_probability[0],
         error_probability[1],
@@ -161,7 +163,7 @@ def AmplitudeDamping(error_probability: float) -> tuple[Array, ...]:
     """
 
     if (error_probability > 1.0) or (error_probability < 0.0):
-        raise ValueError("The damping rate is not a correct probability")
+        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - error_probability)]], dtype=jnp.complex128)
     K1: Array = jnp.array([[0, jnp.sqrt(error_probability)], [0, 0]], dtype=jnp.complex128)
     kraus: tuple[Array, ...] = (K0, K1)
@@ -195,7 +197,7 @@ def PhaseDamping(error_probability: float) -> tuple[Array, ...]:
     """
 
     if (error_probability > 1.0) or (error_probability < 0.0):
-        raise ValueError("The damping rate is not a correct probability")
+        ValueError(f"The 'error_probability' value is incorrect. Got {error_probability}.")
     K0: Array = jnp.array([[1, 0], [0, jnp.sqrt(1 - error_probability)]], dtype=jnp.complex128)
     K1: Array = jnp.array([[0, 0], [0, jnp.sqrt(error_probability)]], dtype=jnp.complex128)
     kraus: tuple[Array, ...] = (K0, K1)
@@ -236,9 +238,11 @@ def GeneralizedAmplitudeDamping(error_probability: tuple[float, ...]) -> tuple[A
     probability = error_probability[0]
     rate = error_probability[1]
     if (probability > 1.0) or (probability < 0.0):
-        raise ValueError("The probability value is not a correct probability")
+        raise ValueError(
+            f"The first value of 'error_probability' value is incorrect. Got {probability}."
+        )
     if (rate > 1.0) or (rate < 0.0):
-        raise ValueError("The damping rate is not a correct probability")
+        raise ValueError(f"The second value of 'error_probability' value is incorrect. Got {rate}.")
 
     K0: Array = jnp.sqrt(probability) * jnp.array(
         [[1, 0], [0, jnp.sqrt(1 - rate)]], dtype=jnp.complex128

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -6,6 +6,8 @@ nav:
   - horqrux in a nutshell: index.md
   - Contribute: CONTRIBUTING.md
   - Code of Conduct: CODE_OF_CONDUCT.md
+  - Advanced Features:
+    - Noisy simulation: noise.md
 
 theme:
   name: material

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "horqrux"
-description = "Jax-based quantum state vector and density matrix simulator."
+description = "Jax-based quantum state vector and noisy simulator."
 authors = [
     { name = "Gert-Jan Both" , email = "gert-jan.both@pasqal.com" },
     { name = "Dominik Seitz", email = "dominik.seitz@pasqal.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "hatchling.build"
 
 [project]
 name = "horqrux"
-description = "Jax-based quantum state vector simulator."
+description = "Jax-based quantum state vector and density matrix simulator."
 authors = [
     { name = "Gert-Jan Both" , email = "gert-jan.both@pasqal.com" },
     { name = "Dominik Seitz", email = "dominik.seitz@pasqal.com" },

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -12,7 +12,7 @@ authors = [
 requires-python = ">=3.8,<3.13"
 license = {text = "Apache 2.0"}
 
-version = "0.6.2"
+version = "0.7.0"
 
 classifiers=[
     "License :: Other/Proprietary License",

--- a/tests/test_adjoint.py
+++ b/tests/test_adjoint.py
@@ -4,8 +4,7 @@ import jax.numpy as jnp
 import numpy as np
 from jax import Array, grad
 
-from horqrux import random_state
-from horqrux.circuit import expectation
+from horqrux import expectation, random_state
 from horqrux.parametric import PHASE, RX, RY, RZ
 from horqrux.primitive import NOT, H, I, S, T, X, Y, Z
 from horqrux.utils import DiffMode
@@ -27,7 +26,7 @@ def test_gradcheck() -> None:
     state = random_state(MAX_QUBITS)
 
     def exp_fn(values: dict, diff_mode: DiffMode = "ad") -> Array:
-        return expectation(state, ops, observable, values, diff_mode)
+        return expectation(state, ops, observable, values, diff_mode).item()
 
     grads_adjoint = grad(exp_fn)(values, "adjoint")
     grad_ad = grad(exp_fn)(values)

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -64,6 +64,16 @@ def test_parametric(gate_fn: Callable) -> None:
         apply_operator(state, gate.dagger(values), gate.target[0], gate.control[0]), orig_state
     )
 
+    # test density matrix is similar to pure state
+    dm = apply_operator(
+        density_mat(orig_state),
+        gate.unitary(values),
+        gate.target[0],
+        gate.control[0],
+        is_state_densitymat=True,
+    )
+    assert jnp.allclose(dm, density_mat(state))
+
 
 @pytest.mark.parametrize("gate_fn", PARAMETRIC_GATES)
 def test_controlled_parametric(gate_fn: Callable) -> None:

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from jax import Array
 
-from horqrux.apply import apply_gate, apply_operator
+from horqrux.apply import apply_gate, apply_operator, apply_operator_dm
 from horqrux.parametric import PHASE, RX, RY, RZ
 from horqrux.primitive import NOT, SWAP, H, I, S, T, X, Y, Z
 from horqrux.utils import density_mat, equivalent_state, product_state, random_state
@@ -29,12 +29,11 @@ def test_primitive(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator(
+    dm = apply_operator_dm(
         density_mat(orig_state),
         gate.unitary(),
         gate.target[0],
         gate.control[0],
-        is_state_densitymat=True,
     )
     assert jnp.allclose(dm, density_mat(state))
 
@@ -53,12 +52,11 @@ def test_controlled_primitive(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator(
+    dm = apply_operator_dm(
         density_mat(orig_state),
         gate.unitary(),
         gate.target[0],
         gate.control[0],
-        is_state_densitymat=True,
     )
     assert jnp.allclose(dm, density_mat(state))
 
@@ -75,12 +73,11 @@ def test_parametric(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator(
+    dm = apply_operator_dm(
         density_mat(orig_state),
         gate.unitary(values),
         gate.target[0],
         gate.control[0],
-        is_state_densitymat=True,
     )
     assert jnp.allclose(dm, density_mat(state))
 
@@ -100,12 +97,11 @@ def test_controlled_parametric(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator(
+    dm = apply_operator_dm(
         density_mat(orig_state),
         gate.unitary(values),
         gate.target[0],
         gate.control[0],
-        is_state_densitymat=True,
     )
     assert jnp.allclose(dm, density_mat(state))
 

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -7,7 +7,7 @@ import numpy as np
 import pytest
 from jax import Array
 
-from horqrux.apply import apply_gate, apply_operator, apply_operator_dm
+from horqrux.apply import apply_gate, apply_operator
 from horqrux.parametric import PHASE, RX, RY, RZ
 from horqrux.primitive import NOT, SWAP, H, I, S, T, X, Y, Z
 from horqrux.utils import density_mat, equivalent_state, product_state, random_state
@@ -29,13 +29,13 @@ def test_primitive(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator_dm(
+    dm = apply_operator(
         density_mat(orig_state),
         gate.unitary(),
         gate.target[0],
         gate.control[0],
     )
-    assert jnp.allclose(dm, density_mat(state))
+    assert jnp.allclose(dm.array, density_mat(state).array)
 
 
 @pytest.mark.parametrize("gate_fn", PRIMITIVE_GATES)
@@ -52,13 +52,13 @@ def test_controlled_primitive(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator_dm(
+    dm = apply_operator(
         density_mat(orig_state),
         gate.unitary(),
         gate.target[0],
         gate.control[0],
     )
-    assert jnp.allclose(dm, density_mat(state))
+    assert jnp.allclose(dm.array, density_mat(state).array)
 
 
 @pytest.mark.parametrize("gate_fn", PARAMETRIC_GATES)
@@ -73,13 +73,13 @@ def test_parametric(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator_dm(
+    dm = apply_operator(
         density_mat(orig_state),
         gate.unitary(values),
         gate.target[0],
         gate.control[0],
     )
-    assert jnp.allclose(dm, density_mat(state))
+    assert jnp.allclose(dm.array, density_mat(state).array)
 
 
 @pytest.mark.parametrize("gate_fn", PARAMETRIC_GATES)
@@ -97,13 +97,13 @@ def test_controlled_parametric(gate_fn: Callable) -> None:
     )
 
     # test density matrix is similar to pure state
-    dm = apply_operator_dm(
+    dm = apply_operator(
         density_mat(orig_state),
         gate.unitary(values),
         gate.target[0],
         gate.control[0],
     )
-    assert jnp.allclose(dm, density_mat(state))
+    assert jnp.allclose(dm.array, density_mat(state).array)
 
 
 @pytest.mark.parametrize(

--- a/tests/test_gates.py
+++ b/tests/test_gates.py
@@ -52,6 +52,16 @@ def test_controlled_primitive(gate_fn: Callable) -> None:
         apply_operator(state, gate.dagger(), gate.target[0], gate.control[0]), orig_state
     )
 
+    # test density matrix is similar to pure state
+    dm = apply_operator(
+        density_mat(orig_state),
+        gate.unitary(),
+        gate.target[0],
+        gate.control[0],
+        is_state_densitymat=True,
+    )
+    assert jnp.allclose(dm, density_mat(state))
+
 
 @pytest.mark.parametrize("gate_fn", PARAMETRIC_GATES)
 def test_parametric(gate_fn: Callable) -> None:
@@ -88,6 +98,16 @@ def test_controlled_parametric(gate_fn: Callable) -> None:
     assert jnp.allclose(
         apply_operator(state, gate.dagger(values), gate.target[0], gate.control[0]), orig_state
     )
+
+    # test density matrix is similar to pure state
+    dm = apply_operator(
+        density_mat(orig_state),
+        gate.unitary(values),
+        gate.target[0],
+        gate.control[0],
+        is_state_densitymat=True,
+    )
+    assert jnp.allclose(dm, density_mat(state))
 
 
 @pytest.mark.parametrize(

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -6,7 +6,7 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
-from horqrux.api import run, sample
+from horqrux.api import expectation, run, sample
 from horqrux.apply import apply_gate
 from horqrux.noise import NoiseInstance, NoiseType
 from horqrux.parametric import PHASE, RX, RY, RZ
@@ -96,6 +96,7 @@ def simple_depolarizing_test() -> None:
     state = product_state("00")
     state_output = run(ops, state)
 
+    # test run
     assert jnp.allclose(
         state_output,
         jnp.array(
@@ -113,6 +114,12 @@ def simple_depolarizing_test() -> None:
         ),
     )
 
-    sampling_output = sample(density_mat(state), ops, is_state_densitymat=True)
+    # test sampling
+    dm_state = density_mat(state)
+    sampling_output = sample(dm_state, ops, is_state_densitymat=True)
     assert "11" in sampling_output.keys()
     assert "01" in sampling_output.keys()
+
+    # test expectation
+    exp_dm = expectation(dm_state, ops, [Z(0)], {})
+    assert jnp.allclose(exp_dm, jnp.array([-0.86666667], dtype=jnp.float64))

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -2,6 +2,7 @@ from __future__ import annotations
 
 from typing import Callable
 
+import jax.numpy as jnp
 import numpy as np
 import pytest
 
@@ -9,7 +10,7 @@ from horqrux.apply import apply_gate
 from horqrux.noise import NoiseInstance, NoiseType
 from horqrux.parametric import PHASE, RX, RY, RZ
 from horqrux.primitive import NOT, H, I, S, T, X, Y, Z
-from horqrux.utils import random_state
+from horqrux.utils import density_mat, random_state
 
 MAX_QUBITS = 7
 PARAMETRIC_GATES = (RX, RY, RZ, PHASE)
@@ -45,10 +46,17 @@ def test_noisy_primitive(gate_fn: Callable, noise_type: NoiseType) -> None:
     noisy_gate = gate_fn(target, noise=(noise,))
     assert len(noisy_gate.noise) == 1
 
+    dm_shape_len = 2 * MAX_QUBITS
+
     orig_state = random_state(MAX_QUBITS)
     output_dm = apply_gate(orig_state, noisy_gate)
     # check output is a density matrix
-    assert len(output_dm.shape) == 2 * MAX_QUBITS
+    assert len(output_dm.shape) == dm_shape_len
+
+    orig_dm = density_mat(orig_state)
+    assert len(orig_dm.shape) == dm_shape_len
+    output_dm2 = apply_gate(orig_dm, noisy_gate, is_state_densitymat=True)
+    assert jnp.allclose(output_dm2, output_dm)
 
 
 @pytest.mark.parametrize("gate_fn", PARAMETRIC_GATES)
@@ -60,6 +68,14 @@ def test_noisy_parametric(gate_fn: Callable, noise_type: NoiseType) -> None:
     values = {"theta": np.random.uniform(0.1, 2 * np.pi)}
     orig_state = random_state(MAX_QUBITS)
 
+    dm_shape_len = 2 * MAX_QUBITS
+
     output_dm = apply_gate(orig_state, noisy_gate, values)
     # check output is a density matrix
-    assert len(output_dm.shape) == 2 * MAX_QUBITS
+    assert len(output_dm.shape) == dm_shape_len
+
+    orig_dm = density_mat(orig_state)
+    assert len(orig_dm.shape) == dm_shape_len
+
+    output_dm2 = apply_gate(orig_dm, noisy_gate, values, is_state_densitymat=True)
+    assert jnp.allclose(output_dm2, output_dm)

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -56,7 +56,7 @@ def test_noisy_primitive(gate_fn: Callable, noise_type: NoiseType) -> None:
 
     orig_dm = density_mat(orig_state)
     assert len(orig_dm.shape) == dm_shape_len
-    output_dm2 = apply_gate(orig_dm, noisy_gate, is_state_densitymat=True)
+    output_dm2 = apply_gate(orig_dm, noisy_gate, is_density=True)
     assert jnp.allclose(output_dm2, output_dm)
 
     perfect_gate = gate_fn(target)
@@ -82,7 +82,7 @@ def test_noisy_parametric(gate_fn: Callable, noise_type: NoiseType) -> None:
     orig_dm = density_mat(orig_state)
     assert len(orig_dm.shape) == dm_shape_len
 
-    output_dm2 = apply_gate(orig_dm, noisy_gate, values, is_state_densitymat=True)
+    output_dm2 = apply_gate(orig_dm, noisy_gate, values, is_density=True)
     assert jnp.allclose(output_dm2, output_dm)
 
     perfect_gate = gate_fn("theta", target)
@@ -116,7 +116,7 @@ def simple_depolarizing_test() -> None:
 
     # test sampling
     dm_state = density_mat(state)
-    sampling_output = sample(dm_state, ops, is_state_densitymat=True)
+    sampling_output = sample(dm_state, ops, is_density=True)
     assert "11" in sampling_output.keys()
     assert "01" in sampling_output.keys()
 

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -52,16 +52,19 @@ def test_noisy_primitive(gate_fn: Callable, noise_type: NoiseType) -> None:
     orig_state = random_state(MAX_QUBITS)
     output_dm = apply_gate(orig_state, noisy_gate)
     # check output is a density matrix
-    assert len(output_dm.shape) == dm_shape_len
+    assert len(output_dm.array.shape) == dm_shape_len
 
     orig_dm = density_mat(orig_state)
-    assert len(orig_dm.shape) == dm_shape_len
-    output_dm2 = apply_gate(orig_dm, noisy_gate, is_density=True)
-    assert jnp.allclose(output_dm2, output_dm)
+    assert len(orig_dm.array.shape) == dm_shape_len
+    output_dm2 = apply_gate(
+        orig_dm,
+        noisy_gate,
+    )
+    assert jnp.allclose(output_dm2.array, output_dm.array)
 
     perfect_gate = gate_fn(target)
     perfect_output = density_mat(apply_gate(orig_state, perfect_gate))
-    assert not jnp.allclose(perfect_output, output_dm)
+    assert not jnp.allclose(perfect_output.array, output_dm.array)
 
 
 @pytest.mark.parametrize("gate_fn", PARAMETRIC_GATES)
@@ -77,17 +80,21 @@ def test_noisy_parametric(gate_fn: Callable, noise_type: NoiseType) -> None:
 
     output_dm = apply_gate(orig_state, noisy_gate, values)
     # check output is a density matrix
-    assert len(output_dm.shape) == dm_shape_len
+    assert len(output_dm.array.shape) == dm_shape_len
 
     orig_dm = density_mat(orig_state)
-    assert len(orig_dm.shape) == dm_shape_len
+    assert len(orig_dm.array.shape) == dm_shape_len
 
-    output_dm2 = apply_gate(orig_dm, noisy_gate, values, is_density=True)
-    assert jnp.allclose(output_dm2, output_dm)
+    output_dm2 = apply_gate(
+        orig_dm,
+        noisy_gate,
+        values,
+    )
+    assert jnp.allclose(output_dm2.array, output_dm.array)
 
     perfect_gate = gate_fn("theta", target)
     perfect_output = density_mat(apply_gate(orig_state, perfect_gate, values))
-    assert not jnp.allclose(perfect_output, output_dm)
+    assert not jnp.allclose(perfect_output.array, output_dm.array)
 
 
 def simple_depolarizing_test() -> None:
@@ -116,7 +123,10 @@ def simple_depolarizing_test() -> None:
 
     # test sampling
     dm_state = density_mat(state)
-    sampling_output = sample(dm_state, ops, is_density=True)
+    sampling_output = sample(
+        dm_state,
+        ops,
+    )
     assert "11" in sampling_output.keys()
     assert "01" in sampling_output.keys()
 

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -51,6 +51,7 @@ def test_noisy_primitive(gate_fn: Callable, noise_type: NoiseType) -> None:
 
     orig_state = random_state(MAX_QUBITS)
     output_dm = apply_gate(orig_state, noisy_gate)
+
     # check output is a density matrix
     assert len(output_dm.array.shape) == dm_shape_len
 

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -6,11 +6,12 @@ import jax.numpy as jnp
 import numpy as np
 import pytest
 
+from horqrux.api import run, sample
 from horqrux.apply import apply_gate
 from horqrux.noise import NoiseInstance, NoiseType
 from horqrux.parametric import PHASE, RX, RY, RZ
 from horqrux.primitive import NOT, H, I, S, T, X, Y, Z
-from horqrux.utils import density_mat, random_state
+from horqrux.utils import density_mat, product_state, random_state
 
 MAX_QUBITS = 7
 PARAMETRIC_GATES = (RX, RY, RZ, PHASE)
@@ -58,6 +59,10 @@ def test_noisy_primitive(gate_fn: Callable, noise_type: NoiseType) -> None:
     output_dm2 = apply_gate(orig_dm, noisy_gate, is_state_densitymat=True)
     assert jnp.allclose(output_dm2, output_dm)
 
+    perfect_gate = gate_fn(target)
+    perfect_output = density_mat(apply_gate(orig_state, perfect_gate))
+    assert not jnp.allclose(perfect_output, output_dm)
+
 
 @pytest.mark.parametrize("gate_fn", PARAMETRIC_GATES)
 @pytest.mark.parametrize("noise_type", ALL_NOISES)
@@ -79,3 +84,35 @@ def test_noisy_parametric(gate_fn: Callable, noise_type: NoiseType) -> None:
 
     output_dm2 = apply_gate(orig_dm, noisy_gate, values, is_state_densitymat=True)
     assert jnp.allclose(output_dm2, output_dm)
+
+    perfect_gate = gate_fn("theta", target)
+    perfect_output = density_mat(apply_gate(orig_state, perfect_gate, values))
+    assert not jnp.allclose(perfect_output, output_dm)
+
+
+def simple_depolarizing_test() -> None:
+    noise = (NoiseInstance(NoiseType.DEPOLARIZING, 0.1),)
+    ops = [X(0, noise=noise), X(1)]
+    state = product_state("00")
+    state_output = run(ops, state)
+
+    assert jnp.allclose(
+        state_output,
+        jnp.array(
+            [
+                [
+                    [[0.0 - 0.0j, 0.0 - 0.0j], [0.0 - 0.0j, 0.0 - 0.0j]],
+                    [[0.0 - 0.0j, 0.06666667 - 0.0j], [0.0 - 0.0j, 0.0 - 0.0j]],
+                ],
+                [
+                    [[0.0 - 0.0j, 0.0 - 0.0j], [0.0 - 0.0j, 0.0 - 0.0j]],
+                    [[0.0 - 0.0j, 0.0 - 0.0j], [0.0 - 0.0j, 0.93333333 - 0.0j]],
+                ],
+            ],
+            dtype=jnp.complex128,
+        ),
+    )
+
+    sampling_output = sample(density_mat(state), ops, is_state_densitymat=True)
+    assert "11" in sampling_output.keys()
+    assert "01" in sampling_output.keys()

--- a/tests/test_noise.py
+++ b/tests/test_noise.py
@@ -11,7 +11,7 @@ from horqrux.apply import apply_gate
 from horqrux.noise import NoiseInstance, NoiseType
 from horqrux.parametric import PHASE, RX, RY, RZ
 from horqrux.primitive import NOT, H, I, S, T, X, Y, Z
-from horqrux.utils import density_mat, product_state, random_state
+from horqrux.utils import ForwardMode, density_mat, product_state, random_state
 
 MAX_QUBITS = 7
 PARAMETRIC_GATES = (RX, RY, RZ, PHASE)
@@ -123,3 +123,9 @@ def simple_depolarizing_test() -> None:
     # test expectation
     exp_dm = expectation(dm_state, ops, [Z(0)], {})
     assert jnp.allclose(exp_dm, jnp.array([-0.86666667], dtype=jnp.float64))
+
+    # test shots expectation
+    exp_dm_shots = expectation(
+        dm_state, ops, [Z(0)], {}, forward_mode=ForwardMode.SHOTS, n_shots=1000
+    )
+    assert jnp.allclose(exp_dm, exp_dm_shots, atol=1e-02)

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -6,6 +6,7 @@ import jax.numpy as jnp
 from horqrux import expectation, random_state
 from horqrux.parametric import RX
 from horqrux.primitive import Z
+from horqrux.utils import density_mat
 
 N_QUBITS = 2
 SHOTS_ATOL = 0.01
@@ -28,10 +29,25 @@ def test_shots() -> None:
             state, ops, observables, values, diff_mode="gpsr", forward_mode="shots", n_shots=N_SHOTS
         )
 
+    def shots_dm(x):
+        values = {"theta": x}
+        return expectation(
+            density_mat(state),
+            ops,
+            observables,
+            values,
+            diff_mode="gpsr",
+            is_state_densitymat=True,
+            forward_mode="shots",
+            n_shots=N_SHOTS,
+        )
+
     exp_exact = exact(x)
     exp_shots = shots(x)
+    exp_shots_dm = shots_dm(x)
 
     assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
+    assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
 
     d_exact = jax.grad(lambda x: exact(x).sum())
     d_shots = jax.grad(lambda x: shots(x).sum())

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -26,7 +26,7 @@ def test_shots() -> None:
     def exact_dm(x):
         values = {"theta": x}
         return expectation(
-            density_mat(state), ops, observables, values, diff_mode="ad", is_state_densitymat=True
+            density_mat(state), ops, observables, values, diff_mode="ad", is_density=True
         )
 
     def shots(x):
@@ -43,7 +43,7 @@ def test_shots() -> None:
             observables,
             values,
             diff_mode="gpsr",
-            is_state_densitymat=True,
+            is_density=True,
             forward_mode="shots",
             n_shots=N_SHOTS,
         )

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -25,9 +25,7 @@ def test_shots() -> None:
 
     def exact_dm(x):
         values = {"theta": x}
-        return expectation(
-            density_mat(state), ops, observables, values, diff_mode="ad", is_density=True
-        )
+        return expectation(density_mat(state), ops, observables, values, diff_mode="ad")
 
     def shots(x):
         values = {"theta": x}
@@ -43,7 +41,6 @@ def test_shots() -> None:
             observables,
             values,
             diff_mode="gpsr",
-            is_density=True,
             forward_mode="shots",
             n_shots=N_SHOTS,
         )

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -22,10 +22,12 @@ def test_shots() -> None:
     def exact(x):
         values = {"theta": x}
         return expectation(state, ops, observables, values, diff_mode="ad")
-    
+
     def exact_dm(x):
         values = {"theta": x}
-        return expectation(density_mat(state), ops, observables, values, diff_mode="ad", is_state_densitymat=True)
+        return expectation(
+            density_mat(state), ops, observables, values, diff_mode="ad", is_state_densitymat=True
+        )
 
     def shots(x):
         values = {"theta": x}

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -22,6 +22,10 @@ def test_shots() -> None:
     def exact(x):
         values = {"theta": x}
         return expectation(state, ops, observables, values, diff_mode="ad")
+    
+    def exact_dm(x):
+        values = {"theta": x}
+        return expectation(density_mat(state), ops, observables, values, diff_mode="ad", is_state_densitymat=True)
 
     def shots(x):
         values = {"theta": x}
@@ -43,6 +47,9 @@ def test_shots() -> None:
         )
 
     exp_exact = exact(x)
+    exp_exact_dm = exact_dm(x)
+    assert jnp.allclose(exp_exact, exp_exact_dm)
+
     exp_shots = shots(x)
     exp_shots_dm = shots_dm(x)
 

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 import jax
 import jax.numpy as jnp
 
-from horqrux import expectation, random_state
+from horqrux import expectation, random_state, run
 from horqrux.parametric import RX
 from horqrux.primitive import Z
 from horqrux.utils import density_mat
@@ -45,17 +45,20 @@ def test_shots() -> None:
             n_shots=N_SHOTS,
         )
 
+    expected_dm = density_mat(run(ops, state, {"theta": x}))
+    output_dm = run(ops, density_mat(state), {"theta": x})
+    assert jnp.allclose(expected_dm.array, output_dm.array)
+
     exp_exact = exact(x)
-    # FIXME: DM expectation not working
-    # exp_exact_dm = exact_dm(x)
-    # assert jnp.allclose(exp_exact, exp_exact_dm)
+    exp_exact_dm = exact_dm(x)
+    assert jnp.allclose(exp_exact, exp_exact_dm)
 
     exp_shots = shots(x)
-    # FIXME: DM expectation not working
-    # exp_shots_dm = shots_dm(x)
+    # # FIXME: DM expectation not working
+    # # exp_shots_dm = shots_dm(x)
 
-    assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
-    # assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
+    # assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
+    # # assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
 
     d_exact = jax.grad(lambda x: exact(x).sum())
     d_shots = jax.grad(lambda x: shots(x).sum())

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -54,11 +54,10 @@ def test_shots() -> None:
     assert jnp.allclose(exp_exact, exp_exact_dm)
 
     exp_shots = shots(x)
-    # FIXME: DM expectation not working
-    # exp_shots_dm = shots_dm(x)
+    exp_shots_dm = shots_dm(x)
 
     assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
-    # assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
+    assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
 
     d_exact = jax.grad(lambda x: exact(x).sum())
     d_shots = jax.grad(lambda x: shots(x).sum())

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -47,13 +47,13 @@ def test_shots() -> None:
 
     exp_exact = exact(x)
     exp_exact_dm = exact_dm(x)
-    assert jnp.allclose(exp_exact, exp_exact_dm)
+    # assert jnp.allclose(exp_exact, exp_exact_dm)
 
     exp_shots = shots(x)
     exp_shots_dm = shots_dm(x)
 
     assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
-    assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
+    # assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
 
     d_exact = jax.grad(lambda x: exact(x).sum())
     d_shots = jax.grad(lambda x: shots(x).sum())

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -46,11 +46,13 @@ def test_shots() -> None:
         )
 
     exp_exact = exact(x)
-    exp_exact_dm = exact_dm(x)
+    # FIXME: DM expectation not working
+    # exp_exact_dm = exact_dm(x)
     # assert jnp.allclose(exp_exact, exp_exact_dm)
 
     exp_shots = shots(x)
-    exp_shots_dm = shots_dm(x)
+    # FIXME: DM expectation not working
+    # exp_shots_dm = shots_dm(x)
 
     assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
     # assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -20,11 +20,13 @@ def test_shots() -> None:
 
     def exact(x):
         values = {"theta": x}
-        return expectation(state, ops, observables, values, "ad")
+        return expectation(state, ops, observables, values, diff_mode="ad")
 
     def shots(x):
         values = {"theta": x}
-        return expectation(state, ops, observables, values, "gpsr", "shots", n_shots=N_SHOTS)
+        return expectation(
+            state, ops, observables, values, diff_mode="gpsr", forward_mode="shots", n_shots=N_SHOTS
+        )
 
     exp_exact = exact(x)
     exp_shots = shots(x)

--- a/tests/test_shots.py
+++ b/tests/test_shots.py
@@ -54,11 +54,11 @@ def test_shots() -> None:
     assert jnp.allclose(exp_exact, exp_exact_dm)
 
     exp_shots = shots(x)
-    # # FIXME: DM expectation not working
-    # # exp_shots_dm = shots_dm(x)
+    # FIXME: DM expectation not working
+    # exp_shots_dm = shots_dm(x)
 
-    # assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
-    # # assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
+    assert jnp.allclose(exp_exact, exp_shots, atol=SHOTS_ATOL)
+    # assert jnp.allclose(exp_exact, exp_shots_dm, atol=SHOTS_ATOL)
 
     d_exact = jax.grad(lambda x: exact(x).sum())
     d_shots = jax.grad(lambda x: shots(x).sum())


### PR DESCRIPTION
Closes #33 by:

- [x] Adding a `NoiseInstance` with different `NoiseType` values from where we can extract the krauss operators.
- [x] Adding a noise argument to gates as a tuple of `NoiseInstance`
- [x] Extending `apply` functions to handle noise and input `State` provided as a density matrix.
- [x] Extending the `api` functions to work with density matrices.
- [x] Adding tests
- [x] Adding section noise in docs
- [x] Removing circuit methods `sample` and `expectation` as they were redundant with the `api`'s